### PR TITLE
Traceparent header, change service name

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -38,10 +38,10 @@ let package = Package(
 			dependencies: ["NautilusTelemetry"],
 			swiftSettings: [
 				.enableUpcomingFeature("BareSlashRegexLiterals")
-			],
+			]
 		),
 		.target(
 			name: "SampleCode",
-			dependencies: ["NautilusTelemetry"]),
+			dependencies: ["NautilusTelemetry"])
 	]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.8
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 // Copyright © 2021 eBay. All rights reserved.
 
@@ -35,7 +35,11 @@ let package = Package(
 			]),
 		.testTarget(
 			name: "NautilusTelemetryTests",
-			dependencies: ["NautilusTelemetry"]),
+			dependencies: ["NautilusTelemetry"],
+			swiftSettings: [
+				.enableUpcomingFeature("BareSlashRegexLiterals")
+			],
+		),
 		.target(
 			name: "SampleCode",
 			dependencies: ["NautilusTelemetry"]),

--- a/Sources/NautilusTelemetry/ResourceAttributes.swift
+++ b/Sources/NautilusTelemetry/ResourceAttributes.swift
@@ -25,7 +25,7 @@ public struct ResourceAttributes {
 	}
 	
 	/// Create a default set of resource attributes.
-	/// - Parameter additionalAttributes: Additional attributes. Must conform to https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/common/attribute-naming.md
+	/// - Parameter additionalAttributes: Additional attributes, that may override existing attributes. Must conform to https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/common/attribute-naming.md
 	/// - Returns: Built attributes.
 	public static func makeWithDefaults(additionalAttributes: TelemetryAttributes?) -> ResourceAttributes {
 		let placeholder = "unknown"
@@ -77,8 +77,9 @@ public struct ResourceAttributes {
 		
 		var attributes = TelemetryAttributes()
 		
-		// https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/semantic_conventions/README.md
-		attributes["service.name"] = bundleIdentifier
+		// https://opentelemetry.io/docs/specs/semconv/registry/attributes/service/
+		attributes["service.name"] = "ios.app"
+		attributes["service.namespace"] = bundleIdentifier
 		attributes["service.version"] = applicationVersion
 		attributes["telemetry.sdk.name"] = "NautilusTelemetry"
 		attributes["telemetry.sdk.language"] = "swift"
@@ -95,8 +96,8 @@ public struct ResourceAttributes {
 		attributes["os.version"] = osVersion
 
 		if let additionalAttributes = additionalAttributes {
-			// Don't overwrite any existing keys.
-			attributes.merge(additionalAttributes) { (current, _) in current }
+			// Overwrite any existing keys.
+			attributes.merge(additionalAttributes) { (_, new) in new }
 		}
 
 		return attributes

--- a/Sources/NautilusTelemetry/Tracing/Span.swift
+++ b/Sources/NautilusTelemetry/Tracing/Span.swift
@@ -34,30 +34,13 @@ public final class Span: Identifiable {
 	var endTime: ContinuousClock.Instant?
 	var retireCallback: ((_: Span) -> Void)?
 
-	/// This can be set by the consuming code to affect the traceParentHeader value.
-	public var sampled: Bool = true
-	
 	var elapsed: Duration? {
 		get {
 			guard let endTime = endTime else { return nil }
 			return endTime-startTime
 		}
 	}
-	
-	/// returns a value that can be used as a "traceparent" header.
-	public var traceParentHeader: String {
-		get {
-			// https://www.w3.org/TR/trace-context/#traceparent-header-field-values
-			
-			var flags: UInt8 = 0x00
-			flags |= sampled ? 1 : 0
-			
-			let hexFlags = Data([flags]).hexEncodedString
-			/// version, trace-id, parent-id, trace-flags
-			return "00-\(traceId.hexEncodedString)-\(id.hexEncodedString)-\(hexFlags)"
-		}
-	}
-	
+
 	internal init(name: String,
 				  kind: SpanKind = .internal,
 				  attributes: TelemetryAttributes? = nil,

--- a/Sources/NautilusTelemetry/Tracing/Tracer.swift
+++ b/Sources/NautilusTelemetry/Tracing/Tracer.swift
@@ -18,7 +18,11 @@ public final class Tracer {
 			return Baggage(span: root)
 		}
 	}
-	
+
+	/// Convenience to track the expected state of sampling
+	/// Traceparent headers use this by default
+	public var isSampling: Bool = false
+
 	var traceId = Identifiers.generateTraceId()
 	var root: Span
 	var retiredSpans = [Span]()
@@ -85,6 +89,8 @@ public final class Tracer {
 
 
 	/// Creates a new subtrace span, with a link to a parent span.
+	/// Subtraces allow creating a tree of traces, making visualization easier.
+	/// Each subtrace should ideally represent a logical sub-area, or user activity.
 	/// - Parameters:
 	///   - name: The name of the new span.
 	///   - kind: the kind of the span - may be left unspecified, but should be set to `.client` for network calls.


### PR DESCRIPTION
- Add `BareSlashRegexLiterals` to the test target
- Allow the consumer to override attribute defaults
- Change default service name to `ios.app`
- Move bundle identifier to `service.namespace`
- Move `isSampling` flag to Tracer
- Improved `traceparent` header helper functions
- Added some better description of subtraces

@bachand 
