### PR TITLE
Add 'target' support to Span.name()

### DIFF
--- a/Sources/NautilusTelemetry/Tracing/Span+URLSession.swift
+++ b/Sources/NautilusTelemetry/Tracing/Span+URLSession.swift
@@ -9,16 +9,18 @@ import Foundation
 public extension Span {
 
 	/// Provides a span name.
-	/// - Parameter request: the request to construct from.
+	/// - Parameters:
+	/// 	- request: the request to construct from.
+	/// 	- target: an optional (low-cardinality) target (e.g. a `url.template` value for HTTP client spans)
 	/// - Returns: a span name.
-	static func name(forRequest request: URLRequest) -> String {
+	static func name(forRequest request: URLRequest, target: String? = nil) -> String {
 		// https://opentelemetry.io/docs/specs/semconv/http/http-spans/#name
 		// HTTP spans MUST follow the overall guidelines for span names.
 		// HTTP span names SHOULD be {method} {target} if there is a (low-cardinality) target available. If there is no (low-cardinality) {target} available, HTTP span names SHOULD be {method}.
 		//	The {method} MUST be {http.request.method} if the method represents the original method known to the instrumentation. In other cases (when {http.request.method} is set to _OTHER), {method} MUST be HTTP.
-
-		// Note: we don't have a way to determine a low cardinality template-based target
-		return request.httpMethod ?? "HTTP"
+		let method = request.httpMethod ?? "HTTP"
+		guard let target else { return method }
+		return "\(method) \(target)"
 	}
 
 	/// Add `traceparent` header to a URLRequest if we're sampling

--- a/Sources/NautilusTelemetry/Tracing/Tracer+URLRequest.swift
+++ b/Sources/NautilusTelemetry/Tracing/Tracer+URLRequest.swift
@@ -10,13 +10,17 @@ public extension Tracer {
 	/// Create a manually managed span to represent an URLRequest that is about to be dispatched.
 	/// - Parameters:
 	///   - for: the URLRequest. The `traceparent` header will be added if needed.
+	///   - template: optional [`url.template`](https://opentelemetry.io/docs/specs/semconv/registry/attributes/url/#url-template) value.
 	///   - attributes: optional attributes.
 	///   - baggage: Optional ``Baggage``, describing parent span. If nil, will be inferred from task/thread local baggage.
 	/// - Returns: A newly created span.
-	func startSpan(for request: inout URLRequest, attributes: TelemetryAttributes? = nil, baggage: Baggage? = nil) -> Span {
-		let name = Span.name(forRequest: request)
+	func startSpan(for request: inout URLRequest, template: String? = nil, attributes: TelemetryAttributes? = nil, baggage: Baggage? = nil) -> Span {
+		let name = Span.name(forRequest: request, target: template)
 		let span = startSpan(name: name, kind: .client, attributes: attributes, baggage: baggage)
 		span.addTraceHeadersIfSampling(&request)
+		if let template {
+			span.addAttribute("url.template", template)
+		}
 		return span
 	}
 }

--- a/Tests/NautilusTelemetryTests/Span+URLSessionTests.swift
+++ b/Tests/NautilusTelemetryTests/Span+URLSessionTests.swift
@@ -20,6 +20,12 @@ final class SpanURLSessionTests: XCTestCase {
 		XCTAssertEqual(Span.name(forRequest: urlRequest), "GET")
 	}
 
+	func testNameWithTarget() {
+		var urlRequest = URLRequest(url: url)
+		urlRequest.httpMethod = "GET"
+		XCTAssertEqual(Span.name(forRequest: urlRequest, target: "/users/:id"), "GET /users/:id")
+	}
+
 	func testUrlSessionDidCreateTask() throws {
 		let span = tracer.startSpan(name: #function)
 		var urlRequest = URLRequest(url: url)


### PR DESCRIPTION
From https://opentelemetry.io/docs/specs/semconv/http/http-spans/#name:

> HTTP span names SHOULD be {method} {target} if there is a
> (low-cardinality) target available.

Because we don't have a way to determine this value directly from the URLRequest within Span.name(), allow the caller to provide it.