### PR TITLE
startSpan(for: URLRequest) sets all request attributes

### DIFF
--- a/Sources/NautilusTelemetry/Tracing/Tracer+URLRequest.swift
+++ b/Sources/NautilusTelemetry/Tracing/Tracer+URLRequest.swift
@@ -11,16 +11,32 @@ public extension Tracer {
 	/// - Parameters:
 	///   - for: the URLRequest. The `traceparent` header will be added if needed.
 	///   - template: optional [`url.template`](https://opentelemetry.io/docs/specs/semconv/registry/attributes/url/#url-template) value.
+	///   - headersToCapture: a set of request headers to capture, or nil to capture none.
 	///   - attributes: optional attributes.
 	///   - baggage: Optional ``Baggage``, describing parent span. If nil, will be inferred from task/thread local baggage.
 	/// - Returns: A newly created span.
-	func startSpan(for request: inout URLRequest, template: String? = nil, attributes: TelemetryAttributes? = nil, baggage: Baggage? = nil) -> Span {
+	func startSpan(for request: inout URLRequest, template: String? = nil, headersToCapture: Set<String>? = nil, attributes: TelemetryAttributes? = nil, baggage: Baggage? = nil) -> Span {
 		let name = Span.name(forRequest: request, target: template)
 		let span = startSpan(name: name, kind: .client, attributes: attributes, baggage: baggage)
-		span.addTraceHeadersIfSampling(&request)
+		span.addAttribute("http.request.method", request.httpMethod ?? "_OTHER")
+		span.addAttribute("user_agent.original", request.value(forHTTPHeaderField: "user-agent"))
+
+		if let url = request.url {
+			span.addAttribute("server.address", url.host)
+			span.addAttribute("server.port", url.port)
+			span.addAttribute("url.full", url.absoluteString)
+		}
 		if let template {
 			span.addAttribute("url.template", template)
 		}
+
+		span.addHeaders(
+			prefix: "http.request.header",
+			headers: request.allHTTPHeaderFields,
+			headersToCapture: headersToCapture
+		)
+		span.addTraceHeadersIfSampling(&request)
+
 		return span
 	}
 }

--- a/Tests/NautilusTelemetryTests/Span+URLSessionTests.swift
+++ b/Tests/NautilusTelemetryTests/Span+URLSessionTests.swift
@@ -2,8 +2,6 @@
 // Copyright © 2025 Airbnb Inc. All rights reserved.
 
 import Foundation
-
-import Foundation
 import XCTest
 
 @testable import NautilusTelemetry

--- a/Tests/NautilusTelemetryTests/Tracer+URLRequestTests.swift
+++ b/Tests/NautilusTelemetryTests/Tracer+URLRequestTests.swift
@@ -1,0 +1,26 @@
+// Created by Jon Parise on 6/9/25.
+// Copyright © 2025 Airbnb Inc. All rights reserved.
+
+import Foundation
+import XCTest
+
+@testable import NautilusTelemetry
+
+final class TracerURLRequestTests: XCTestCase {
+	let tracer = Tracer()
+	let url = URL(string: "http://www.example.com")!
+
+	func testStartSpanWithRequestAttributes() throws {
+		var urlRequest = URLRequest(url: url)
+		urlRequest.addValue("application/json", forHTTPHeaderField: "Content-Type")
+
+		let span = tracer.startSpan(for: &urlRequest, template: "/users/:id", headersToCapture: Set(["content-type"]))
+		XCTAssertEqual(span.name, "GET /users/:id")
+
+		let attributes = try XCTUnwrap(span.attributes as? [String: String])
+		XCTAssertEqual(attributes["server.address"], url.host())
+		XCTAssertEqual(attributes["http.request.method"], urlRequest.httpMethod)
+		XCTAssertEqual(attributes["http.request.header.content-type"], "application/json")
+		XCTAssertEqual(attributes["url.template"], "/users/:id")
+	}
+}


### PR DESCRIPTION
Set the full set of URLRequest-derived span attributes. These were previously only set by urlSession(_:didCreateTask:), but we have all of the context we need to set them here.

This makes urlSession(_:didCreateTask:) entirely optional to call when a span is constructed from a URLRequest. Doing so will result in the delegate call replacing/updating the values added by startSpan(), which might be useful if some URLRequest properties (such as headers) were set in the interim.