### PR TITLE
Improve addHeaders implementation

### DIFF
--- a/Sources/NautilusTelemetry/Tracing/Span+URLSession.swift
+++ b/Sources/NautilusTelemetry/Tracing/Span+URLSession.swift
@@ -153,7 +153,7 @@ public extension Span {
 	/// - Parameters:
 	///   - request: URLRequest containing headers
 	///   - captureHeaders: Headers to capture. Must be lowercase strings.
-	internal func addHeaders(request: URLRequest, captureHeaders: Set<String>? = nil) {
+	func addHeaders(request: URLRequest, captureHeaders: Set<String>? = nil) {
 		//  [1] http.request.header: Instrumentations SHOULD require an explicit configuration of which headers are to be captured. Including all request headers can be a security risk - explicit configuration helps avoid leaking sensitive information. The User-Agent header is already captured in the user_agent.original attribute. Users MAY explicitly configure instrumentations to capture them even though it is not recommended. The attribute value MUST consist of either multiple header values as an array of strings or a single-item array containing a possibly comma-concatenated string, depending on the way the HTTP library provides access to headers.
 
 		guard let captureHeaders = captureHeaders else { return }
@@ -170,7 +170,7 @@ public extension Span {
 	/// - Parameters:
 	///   - request: HTTPURLResponse containing headers
 	///   - captureHeaders: Headers to capture. Must be lowercase strings.
-	internal func addHeaders(response: HTTPURLResponse, captureHeaders: Set<String>? = nil) {
+	func addHeaders(response: HTTPURLResponse, captureHeaders: Set<String>? = nil) {
 		guard let captureHeaders = captureHeaders else { return }
 		validate(captureHeaders: captureHeaders)
 
@@ -181,7 +181,7 @@ public extension Span {
 		}
 	}
 
-	internal func validate(captureHeaders: Set<String>) {
+	func validate(captureHeaders: Set<String>) {
 #if DEBUG
 		for header in captureHeaders {
 			assert(header.lowercased() == header, "expected all header names to be lowercased")
@@ -207,7 +207,7 @@ public extension Span {
 	/// Returns the name / value pair for the traceparent header
 	/// - Parameter sampled: Whether we are sampling
 	/// - Returns: a traceparent header
-	internal func traceParentHeaderValue(sampled: Bool) -> (String, String) {
+	func traceParentHeaderValue(sampled: Bool) -> (String, String) {
 		// https://www.w3.org/TR/trace-context/#traceparent-header-field-values
 		var flags: UInt8 = 0x00
 		flags |= sampled ? 1 : 0

--- a/Sources/NautilusTelemetry/Tracing/Tracer+URLRequest.swift
+++ b/Sources/NautilusTelemetry/Tracing/Tracer+URLRequest.swift
@@ -6,7 +6,7 @@ import Foundation
 /// Extensions to be called by the application's URLSession delegate
 
 public extension Tracer {
-	
+
 	/// Create a manually managed span to represent an URLRequest that is about to be dispatched.
 	/// - Parameters:
 	///   - request: the URLRequest. The `traceparent` header will be added if needed.
@@ -30,12 +30,8 @@ public extension Tracer {
 			span.addAttribute("url.template", template)
 		}
 
-		span.addHeaders(
-			prefix: "http.request.header",
-			headers: request.allHTTPHeaderFields,
-			captureHeaders: captureHeaders
-		)
 		span.addTraceHeadersIfSampling(&request, isSampling: isSampling)
+		span.addHeaders(request: request, captureHeaders: captureHeaders)
 
 		return span
 	}

--- a/Sources/NautilusTelemetry/Utilities/Sampling.swift
+++ b/Sources/NautilusTelemetry/Utilities/Sampling.swift
@@ -73,7 +73,7 @@ public final class StableGuidSampler: Sampler {
 	
 	public private(set) var shouldSample: Bool
 
-	internal func computeShouldSample() {
+	func computeShouldSample() {
 		var hash = SHA256.init()
 		hash.update(data: seed)
 		hash.update(data: guid)

--- a/Tests/NautilusTelemetryTests/Span+URLSessionTests.swift
+++ b/Tests/NautilusTelemetryTests/Span+URLSessionTests.swift
@@ -75,4 +75,26 @@ final class SpanURLSessionTests: XCTestCase {
 			}
 		}
 	}
+
+	func testRequestAddHeaders() throws {
+		let span = tracer.startSpan(name: #function)
+		var urlRequest = URLRequest(url: url)
+		urlRequest.addValue("Hello", forHTTPHeaderField: "Greeting")
+		urlRequest.addValue("content-encoding", forHTTPHeaderField: "br")
+		span.addHeaders(request: urlRequest, captureHeaders: Set(["greeting"]))
+		let attributes = try XCTUnwrap(span.attributes)
+		XCTAssertEqual(attributes["http.request.header.greeting"], "Hello")
+		XCTAssertNil(attributes["http.request.header.content-encoding"])
+	}
+
+	func testResponseAddHeaders() throws {
+		let span = tracer.startSpan(name: #function)
+		let headers = ["Fruit": "Banana", "Content-Encoding": "gzip"]
+		let urlResponse = try XCTUnwrap(HTTPURLResponse(url: url, statusCode: 200, httpVersion: "2", headerFields: headers))
+		span.addHeaders(response: urlResponse, captureHeaders: Set(["fruit"]))
+		let attributes = try XCTUnwrap(span.attributes)
+		XCTAssertEqual(attributes["http.response.header.fruit"], "Banana")
+		XCTAssertNil(attributes["http.response.header.content-encoding"])
+	}
+
 }


### PR DESCRIPTION
- Split addHeaders into `URLRequest` and `HTTPURLResponse` variants. This lets us avoid bridging the whole set of HTTP headers. Quick/lazy measurement shows this improving `addHeaders` performance from 22µs to 6µs.
- Switch order of `addTraceHeadersIfSampling` / `addHeaders`, so it's possible to capture the generated `traceparent` header.
- Remove some redundant `internal` declarations
- Indentation

@jparise 