### PR TITLE
Introduce URLTemplateMatcher

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -34,6 +34,9 @@ let package = Package(
 				"Exporters/OTLP-JSON/Trace/trace_service.yaml",
 				"Exporters/OTLP-JSON/Logs/logs_service.yaml",
 				"Instrumentation/MetricKit-sample.json",
+			],
+			swiftSettings: [
+				.enableUpcomingFeature("BareSlashRegexLiterals"),
 			]
 		),
 		.testTarget(

--- a/Sources/NautilusTelemetry/Tracing/URLTemplateMatcher.swift
+++ b/Sources/NautilusTelemetry/Tracing/URLTemplateMatcher.swift
@@ -28,17 +28,23 @@ import Foundation
 ///
 /// ## Examples
 ///
+/// Initialize a matcher with a list of templates. This should be done once
+/// and then reused.
 /// ```swift
 /// let matcher = try URLTemplateMatcher(templates: [
 ///     "/users/{id}",
 ///     "/posts/{postId}/comments/{commentId}",
 ///     "/search?q={}&status=active"
 /// ])
+///```
 ///
+/// Attempt to match a URL with one of our templates:
+/// ```swift
 /// let url = URL(string: "https://api.example.com/users/123")!
 /// let matchedTemplate = matcher.match(url: url) // Returns "/users/{id}"
 /// ```
 ///
+/// Attempt to match a URL template when starting a Span:
 /// ```swift
 /// let span = tracer.startSpan(
 ///     request: request,

--- a/Sources/NautilusTelemetry/Tracing/URLTemplateMatcher.swift
+++ b/Sources/NautilusTelemetry/Tracing/URLTemplateMatcher.swift
@@ -52,9 +52,12 @@ public struct URLTemplateMatcher {
 	/// Creates a matcher with the given URL templates.
 	/// - Parameter templates: Array of URL template strings
 	/// - Throws: If any template contains invalid syntax
-	public init(templates: [String]) throws {
-		self.templates = try templates.map { template in
-			try URLTemplate(template: template)
+	public init(templates: [StaticString]) throws {
+		self.templates = try templates.map {
+			let template = $0.withUTF8Buffer {
+				String(decoding: $0, as: UTF8.self)
+			}
+			return try URLTemplate(template: template)
 		}
 	}
 
@@ -64,7 +67,7 @@ public struct URLTemplateMatcher {
 	/// returns `nil`.
 	///
 	/// - Parameter templates: Array of URL template strings
-	public init?(_ templates: [String]) {
+	public init?(_ templates: [StaticString]) {
 		try? self.init(templates: templates)
 	}
 

--- a/Sources/NautilusTelemetry/Tracing/URLTemplateMatcher.swift
+++ b/Sources/NautilusTelemetry/Tracing/URLTemplateMatcher.swift
@@ -1,0 +1,199 @@
+// Created by Jon Parise on 6/20/25.
+// Copyright © 2025 Airbnb Inc. All rights reserved.
+
+import Foundation
+
+// MARK: - URLTemplateMatcher
+
+/// Matches URLs against a collection of URL template patterns.
+///
+/// Template patterns describe a URL path and query string. They can use
+/// templated parameters like {} or {id} to match dynamic portions of the
+/// path and query parameter values (e.g. "/users/{id}?status={status}").
+///
+/// ## Template Syntax
+///
+/// - Path parameters: `/users/{userId}`
+/// - Query parameters: `?status={status}`
+/// - Literal query values: `?status=active`
+/// - Mixed: `/users/{id}?status={status}&verified=true`
+///
+/// ## Query Parameters
+///
+/// Query parameters can appear in any order to match. Any query parameters
+/// that aren't named in the template are ignored.
+///
+/// If a literal query parameter pair (e.g. "status=active") is included in
+/// the template, it must appear exactly that way in the URL for it to match.
+///
+/// ## Examples
+///
+/// ```swift
+/// let matcher = try URLTemplateMatcher(templates: [
+///     "/users/{id}",
+///     "/posts/{postId}/comments/{commentId}",
+///     "/search?q={}&status=active"
+/// ])
+///
+/// let url = URL(string: "https://api.example.com/users/123")!
+/// let matchedTemplate = matcher.match(url: url) // Returns "/users/{id}"
+/// ```
+///
+/// ```swift
+/// let span = tracer.startSpan(
+///     request: request,
+///     template: matcher.match(request.url)
+/// )
+/// ```
+public struct URLTemplateMatcher {
+
+	// MARK: Lifecycle
+
+	/// Creates a matcher with the given URL templates.
+	/// - Parameter templates: Array of URL template strings
+	/// - Throws: If any template contains invalid syntax
+	public init(templates: [String]) throws {
+		self.templates = try templates.map { template in
+			try URLTemplate(template: template)
+		}
+	}
+
+	/// Creates a matcher with the given URL templates.
+	///
+	/// If any of the templates contains invalid syntax, the initializer
+	/// returns `nil`.
+	///
+	/// - Parameter templates: Array of URL template strings
+	public init?(_ templates: [String]) {
+		try? self.init(templates: templates)
+	}
+
+	// MARK: Public
+
+	/// Returns the template string of the first template that matches the URL.
+	/// - Parameter url: The URL to match
+	/// - Returns: The matching template string, or nil if no templates match
+	public func match(url: URL?) -> String? {
+		guard let url else { return nil }
+		return templates.first { $0.matches(url: url) }?.template
+	}
+
+	// MARK: Private
+
+	private let templates: [URLTemplate]
+}
+
+// MARK: - URLTemplate
+
+/// A URL template pattern that can match against URL paths and query parameters.
+struct URLTemplate {
+
+	// MARK: Lifecycle
+
+	init(template: String) throws {
+		self.template = template
+
+		// Split template into path and query components
+		let components = template[...].split(separator: "?", maxSplits: 1)
+		let pathTemplate = components[0]
+		let queryTemplate = components.count > 1 ? components[1] : nil
+
+		// Build the path-matching regex
+		let pathPattern = pathTemplate.replacing(Self.parameterRegex, with: "[^/?]+")
+		pathRegex = try Regex(String(pathPattern))
+
+		// Parse any required query parameters from the template
+		if let queryTemplate {
+			(
+				requiredTemplatedParameters,
+				requiredLiteralParameters
+			) = Self.parseRequiredParameters(from: queryTemplate)
+		} else {
+			requiredTemplatedParameters = []
+			requiredLiteralParameters = [:]
+		}
+	}
+
+	// MARK: Internal
+
+	let template: String
+
+	func matches(url: URL) -> Bool {
+		// Check that the full path matches
+		guard (try? pathRegex.wholeMatch(in: url.path())) != nil else {
+			return false
+		}
+
+		// Check query parameters if any are required
+		if hasRequiredParameters {
+			guard let query = url.query() else {
+				return false
+			}
+
+			let queryParameters = Dictionary(
+				parseQueryStringPairs(from: query[...]),
+				uniquingKeysWith: { first, _ in first }
+			)
+
+			// Check that all required templated parameters are present
+			for templatedParam in requiredTemplatedParameters {
+				guard queryParameters[templatedParam] != nil else {
+					return false
+				}
+			}
+
+			// Check that all required literal parameter pairs match exactly
+			for (name, requiredValue) in requiredLiteralParameters {
+				guard queryParameters[name] == requiredValue else {
+					return false
+				}
+			}
+		}
+
+		return true
+	}
+
+	// MARK: Private
+
+	/// Regex for matching parameters like {} and {id} in both path and query
+	private static let parameterRegex = /\{[a-zA-Z0-9-_]*\}/
+
+	private let pathRegex: Regex<Substring>
+	private let requiredTemplatedParameters: Set<Substring>
+	private let requiredLiteralParameters: [Substring: Substring]
+
+	private var hasRequiredParameters: Bool {
+		!requiredTemplatedParameters.isEmpty || !requiredLiteralParameters.isEmpty
+	}
+
+	/// Extracts templated and literal parameter pairs from a query template string.
+	private static func parseRequiredParameters(from queryTemplate: Substring)
+		-> (templated: Set<Substring>, literal: [Substring: Substring])
+	{
+		var templatedParams: Set<Substring> = []
+		var literalParams: [Substring: Substring] = [:]
+
+		for (name, value) in parseQueryStringPairs(from: queryTemplate) {
+			if (try? parameterRegex.wholeMatch(in: value)) != nil {
+				templatedParams.insert(name)
+			} else {
+				literalParams[name] = value
+			}
+		}
+
+		return (templated: templatedParams, literal: literalParams)
+	}
+}
+
+/// Extracts the list of (name, value) pairs from a URL query string.
+private func parseQueryStringPairs(from query: Substring) -> [(Substring, Substring)] {
+	query
+		.split(separator: "&")
+		.compactMap { pair in
+			guard let equalIndex = pair.firstIndex(of: "=") else { return nil }
+			return (
+				pair.prefix(upTo: equalIndex),
+				pair.suffix(from: pair.index(after: equalIndex))
+			)
+		}
+}

--- a/Tests/NautilusTelemetryTests/URLTemplateMatcherTests.swift
+++ b/Tests/NautilusTelemetryTests/URLTemplateMatcherTests.swift
@@ -1,0 +1,204 @@
+// Created by Jon Parise on 6/20/25.
+// Copyright © 2025 Airbnb Inc. All rights reserved.
+
+import Foundation
+import XCTest
+
+@testable import NautilusTelemetry
+
+final class URLTemplateMatcherTests: XCTestCase {
+
+	// MARK: - Path Matching Tests
+
+	func testSimplePathMatching() throws {
+		let matcher = try URLTemplateMatcher(templates: ["/users/{id}"])
+
+		XCTAssertEqual(matcher.match(url: URL(string: "https://example.com/users/123")!), "/users/{id}")
+		XCTAssertEqual(matcher.match(url: URL(string: "https://example.com/users/abc")!), "/users/{id}")
+		XCTAssertNil(matcher.match(url: URL(string: "https://example.com/posts/123")!))
+		XCTAssertNil(matcher.match(url: URL(string: "https://example.com/users")!))
+	}
+
+	func testMultiplePathParameters() throws {
+		let matcher = try URLTemplateMatcher(templates: ["/posts/{postId}/comments/{commentId}"])
+
+		XCTAssertEqual(
+			matcher.match(url: URL(string: "https://example.com/posts/123/comments/456")!),
+			"/posts/{postId}/comments/{commentId}"
+		)
+		XCTAssertNil(matcher.match(url: URL(string: "https://example.com/posts/123/comments")!))
+		XCTAssertNil(matcher.match(url: URL(string: "https://example.com/posts/123")!))
+	}
+
+	func testLiteralPathMatching() throws {
+		let matcher = try URLTemplateMatcher(templates: ["/api/v1/users"])
+
+		XCTAssertEqual(matcher.match(url: URL(string: "https://example.com/api/v1/users")!), "/api/v1/users")
+		XCTAssertNil(matcher.match(url: URL(string: "https://example.com/api/v2/users")!))
+	}
+
+	// MARK: - Query Parameter Tests
+
+	func testTemplatedQueryParameters() throws {
+		let matcher = try URLTemplateMatcher(templates: ["/search?q={query}"])
+
+		XCTAssertEqual(
+			matcher.match(url: URL(string: "https://example.com/search?q=test")!),
+			"/search?q={query}"
+		)
+		XCTAssertEqual(
+			matcher.match(url: URL(string: "https://example.com/search?q=test&other=value")!),
+			"/search?q={query}"
+		)
+		XCTAssertNil(matcher.match(url: URL(string: "https://example.com/search")!))
+		XCTAssertNil(matcher.match(url: URL(string: "https://example.com/search?other=value")!))
+	}
+
+	func testLiteralQueryParameters() throws {
+		let matcher = try URLTemplateMatcher(templates: ["/users?status=active"])
+
+		XCTAssertEqual(
+			matcher.match(url: URL(string: "https://example.com/users?status=active")!),
+			"/users?status=active"
+		)
+		XCTAssertEqual(
+			matcher.match(url: URL(string: "https://example.com/users?status=active&other=value")!),
+			"/users?status=active"
+		)
+		XCTAssertNil(matcher.match(url: URL(string: "https://example.com/users?status=inactive")!))
+		XCTAssertNil(matcher.match(url: URL(string: "https://example.com/users")!))
+	}
+
+	func testMixedQueryParameters() throws {
+		let matcher = try URLTemplateMatcher(templates: ["/users?status={status}&verified=true"])
+
+		XCTAssertEqual(
+			matcher.match(url: URL(string: "https://example.com/users?status=active&verified=true")!),
+			"/users?status={status}&verified=true"
+		)
+		XCTAssertEqual(
+			matcher.match(url: URL(string: "https://example.com/users?verified=true&status=inactive")!),
+			"/users?status={status}&verified=true"
+		)
+		XCTAssertNil(matcher.match(url: URL(string: "https://example.com/users?status=active&verified=false")!))
+		XCTAssertNil(matcher.match(url: URL(string: "https://example.com/users?status=active")!))
+	}
+
+	func testQueryParameterOrder() throws {
+		let matcher = try URLTemplateMatcher(templates: ["/search?q={query}&sort={sort}"])
+
+		XCTAssertEqual(
+			matcher.match(url: URL(string: "https://example.com/search?q=test&sort=date")!),
+			"/search?q={query}&sort={sort}"
+		)
+		XCTAssertEqual(
+			matcher.match(url: URL(string: "https://example.com/search?sort=date&q=test")!),
+			"/search?q={query}&sort={sort}"
+		)
+	}
+
+	// MARK: - Complex Template Tests
+
+	func testPathWithQueryParameters() throws {
+		let matcher = try URLTemplateMatcher(templates: ["/users/{id}?include={fields}"])
+
+		XCTAssertEqual(
+			matcher.match(url: URL(string: "https://example.com/users/123?include=profile")!),
+			"/users/{id}?include={fields}"
+		)
+		XCTAssertNil(matcher.match(url: URL(string: "https://example.com/users/123")!))
+		XCTAssertNil(matcher.match(url: URL(string: "https://example.com/posts/123?include=profile")!))
+	}
+
+	// MARK: - Multiple Template Tests
+
+	func testMultipleTemplates() throws {
+		let matcher = try URLTemplateMatcher(templates: [
+			"/users/{id}",
+			"/posts/{id}",
+			"/search?q={query}",
+		])
+
+		XCTAssertEqual(matcher.match(url: URL(string: "https://example.com/users/123")!), "/users/{id}")
+		XCTAssertEqual(matcher.match(url: URL(string: "https://example.com/posts/456")!), "/posts/{id}")
+		XCTAssertEqual(matcher.match(url: URL(string: "https://example.com/search?q=test")!), "/search?q={query}")
+		XCTAssertNil(matcher.match(url: URL(string: "https://example.com/comments/789")!))
+	}
+
+	func testMultipleMatchingTemplates() throws {
+		let matcher = try URLTemplateMatcher(templates: [
+			"/api/{version}/users",
+			"/api/v1/users",
+		])
+
+		// Should match the first template since it's more general
+		XCTAssertEqual(
+			matcher.match(url: URL(string: "https://example.com/api/v1/users")!),
+			"/api/{version}/users"
+		)
+	}
+
+	// MARK: - Edge Cases
+
+	func testEmptyTemplates() throws {
+		let matcher = try URLTemplateMatcher(templates: [])
+		XCTAssertNil(matcher.match(url: URL(string: "https://example.com/users/123")!))
+	}
+
+	func testNilURL() throws {
+		let matcher = try URLTemplateMatcher(templates: ["/users/{id}"])
+		XCTAssertNil(matcher.match(url: nil))
+	}
+
+	func testURLWithoutQuery() throws {
+		let matcher = try URLTemplateMatcher(templates: ["/users/{id}"])
+		XCTAssertEqual(matcher.match(url: URL(string: "https://example.com/users/123")!), "/users/{id}")
+	}
+
+	func testURLWithEmptyQuery() throws {
+		let matcher = try URLTemplateMatcher(templates: ["/users/{id}"])
+		XCTAssertEqual(matcher.match(url: URL(string: "https://example.com/users/123?")!), "/users/{id}")
+	}
+
+	func testAnonymousParameters() throws {
+		let matcher = try URLTemplateMatcher(templates: [
+			"/users/{}",
+			"/posts/{id}/{}",
+			"/search?q={}",
+		])
+
+		XCTAssertEqual(matcher.match(url: URL(string: "https://example.com/users/123")!), "/users/{}")
+		XCTAssertEqual(matcher.match(url: URL(string: "https://example.com/posts/456/title")!), "/posts/{id}/{}")
+		XCTAssertEqual(matcher.match(url: URL(string: "https://example.com/search?q=test")!), "/search?q={}")
+	}
+
+	func testSpecialCharactersInParameters() throws {
+		let matcher = try URLTemplateMatcher(templates: ["/users/{user_id}", "/posts/{post-id}"])
+
+		XCTAssertEqual(matcher.match(url: URL(string: "https://example.com/users/123")!), "/users/{user_id}")
+		XCTAssertEqual(matcher.match(url: URL(string: "https://example.com/posts/456")!), "/posts/{post-id}")
+	}
+
+	func testRootPath() throws {
+		let matcher = try URLTemplateMatcher(templates: ["/"])
+		XCTAssertEqual(matcher.match(url: URL(string: "https://example.com/")!), "/")
+		XCTAssertNil(matcher.match(url: URL(string: "https://example.com/users")!))
+	}
+
+	func testPathWithSlashes() throws {
+		let matcher = try URLTemplateMatcher(templates: ["/api/v1/{resource}"])
+
+		XCTAssertEqual(matcher.match(url: URL(string: "https://example.com/api/v1/users")!), "/api/v1/{resource}")
+		// Path parameters shouldn't match slashes
+		XCTAssertNil(matcher.match(url: URL(string: "https://example.com/api/v1/users/123")!))
+	}
+
+	func testDuplicateQueryParameters() throws {
+		let matcher = try URLTemplateMatcher(templates: ["/search?q={query}"])
+
+		XCTAssertEqual(
+			matcher.match(url: URL(string: "https://example.com/search?q=first&q=second")!),
+			"/search?q={query}"
+		)
+	}
+}


### PR DESCRIPTION
URLTemplateMatcher matches URLs against a collection of URL template patterns. Template patterns describe a URL path and query string. They can use templated parameters like {} or {id} to match dynamic portions of the path and query parameter values ("/users/{id}?status={status}").

This is useful for creating an explicit list of possible URL template values and then selecting the best match for a given URL. This template value can then be used to to construct the Span; the template will be used to form the Span's name and added as the "url.template" attribute.