### PR TITLE
Fix server.address implementation

### DIFF
--- a/Sources/NautilusTelemetry/Tracing/Span+URLSession.swift
+++ b/Sources/NautilusTelemetry/Tracing/Span+URLSession.swift
@@ -70,14 +70,10 @@ extension Span {
 		addAttribute("http.response.body.size", metric.countOfResponseBodyBytesReceived)
 
 		if let remoteAddress = metric.remoteAddress {
-			addAttribute("server.address", remoteAddress)
+			addAttribute("network.peer.address", remoteAddress)
 
 			let isV6 = remoteAddress.contains(":")
 			addAttribute("network.type", isV6 ? "ipv6" : "ipv4")
-		}
-
-		if let remoteAddress = metric.remoteAddress {
-			addAttribute("network.peer.address", remoteAddress)
 
 			if let remotePort = metric.remotePort {
 				addAttribute("network.peer.port", remotePort)
@@ -334,5 +330,4 @@ extension Span {
 		510: "Not Extended",
 		511: "Network Authentication Required",
 	]
-
 }


### PR DESCRIPTION
- `server.address` was being set to `url.host`, then overwritten with `metric.remoteAddress`. Per spec, `server.address` is url host, `network.peer.address` is resolved IP address. Fixed this snafu.
- Removed duplicate `if let remoteAddress = metric.remoteAddress` block.

@jparise 