### PR TITLE
Improved subtrace linking

### DIFF
--- a/Sources/NautilusTelemetry/Exporters/Exporter+Trace.swift
+++ b/Sources/NautilusTelemetry/Exporters/Exporter+Trace.swift
@@ -91,25 +91,21 @@ extension Exporter {
 	}
 
 	func buildLinks(_ span: Span) -> [OTLP.SpanLink]? {
-		guard let links = span.links else { return nil }
+		span.links?.map { link in
+			let attributes: [OTLP.V1KeyValue]?
+			let key = "relationship"
 
-		return links.map { mapLink($0) }
-	}
+			switch link.relationship {
+			case .undefined:
+				attributes = nil
+			case .child:
+				attributes = [OTLP.V1KeyValue(key: key, value: OTLP.V1AnyValue(stringValue: "child"))]
+			case .parent:
+				attributes = [OTLP.V1KeyValue(key: key, value: OTLP.V1AnyValue(stringValue: "parent"))]
+			}
 
-	func mapLink(_ link: Link) -> OTLP.SpanLink {
-		let attributes: [OTLP.V1KeyValue]?
-		let key = "relationship"
-
-		switch link.relationship {
-		case .undefined:
-			attributes = nil
-		case .child:
-			attributes = [OTLP.V1KeyValue(key: key, value: OTLP.V1AnyValue(stringValue: "child"))]
-		case .parent:
-			attributes = [OTLP.V1KeyValue(key: key, value: OTLP.V1AnyValue(stringValue: "parent"))]
+			return OTLP.SpanLink(traceId: link.traceId, spanId: link.id, attributes: attributes)
 		}
-
-		return OTLP.SpanLink(traceId: link.traceId, spanId: link.id, attributes: attributes)
 	}
 
 	/// Converts Span.Status to OTLP.V1Status

--- a/Sources/NautilusTelemetry/Exporters/Exporter+Trace.swift
+++ b/Sources/NautilusTelemetry/Exporters/Exporter+Trace.swift
@@ -91,8 +91,25 @@ extension Exporter {
 	}
 
 	func buildLinks(_ span: Span) -> [OTLP.SpanLink]? {
-		guard let linkedParent = span.linkedParent else { return nil }
-		return [OTLP.SpanLink(traceId: linkedParent.traceId, spanId: linkedParent.id)]
+		guard let links = span.links else { return nil }
+
+		return links.map { mapLink($0) }
+	}
+
+	func mapLink(_ link: Link) -> OTLP.SpanLink {
+		let attributes: [OTLP.V1KeyValue]?
+		let key = "relationship"
+
+		switch link.relationship {
+		case .undefined:
+			attributes = nil
+		case .child:
+			attributes = [OTLP.V1KeyValue(key: key, value: OTLP.V1AnyValue(stringValue: "child"))]
+		case .parent:
+			attributes = [OTLP.V1KeyValue(key: key, value: OTLP.V1AnyValue(stringValue: "parent"))]
+		}
+
+		return OTLP.SpanLink(traceId: link.traceId, spanId: link.id, attributes: attributes)
 	}
 
 	/// Converts Span.Status to OTLP.V1Status

--- a/Sources/NautilusTelemetry/Tracing/Baggage.swift
+++ b/Sources/NautilusTelemetry/Tracing/Baggage.swift
@@ -10,11 +10,19 @@ import os
 
 // MARK: - SubtraceLinking
 
-public enum SubtraceLinking {
-	case none // don't link subtraces
-	case up // link from child to parent
-	case down // link from parent to child
-	case bidirectional // link both directions
+public struct SubtraceLinking: OptionSet {
+
+	public init(rawValue: Int) {
+		self.rawValue = rawValue
+	}
+
+	public let rawValue: Int
+
+	/// link from child to parent
+	public static let up = SubtraceLinking(rawValue: 1 << 0)
+
+	/// link from parent to child
+	public static let down = SubtraceLinking(rawValue: 1 << 1)
 }
 
 // MARK: - Baggage
@@ -27,8 +35,8 @@ public final class Baggage: @unchecked Sendable {
 	/// - Parameters:
 	///   - span: a parent span.
 	///   - subTraceId: an optional TraceId, overriding the parent span's, allowing for the creation of subtraces.
-	///   - subtraceLinking: whether to link between subtrace and parent trace, and in which direction(s)
-	public init(span: Span, subTraceId: TraceId? = nil, subtraceLinking: SubtraceLinking = .bidirectional) {
+	///   - subtraceLinking: whether to link between subtrace and parent trace, and in which direction(s). Defaults to bidirectional.
+	public init(span: Span, subTraceId: TraceId? = nil, subtraceLinking: SubtraceLinking = [.up, .down]) {
 		self.span = span
 		self.subTraceId = subTraceId
 		self.subtraceLinking = subtraceLinking

--- a/Sources/NautilusTelemetry/Tracing/Baggage.swift
+++ b/Sources/NautilusTelemetry/Tracing/Baggage.swift
@@ -8,6 +8,17 @@
 import Foundation
 import os
 
+// MARK: - SubtraceLinking
+
+public enum SubtraceLinking {
+	case none // don't link subtraces
+	case up // link from child to parent
+	case down // link from parent to child
+	case bidirectional // link both directions
+}
+
+// MARK: - Baggage
+
 public final class Baggage: @unchecked Sendable {
 
 	// MARK: Lifecycle
@@ -16,9 +27,11 @@ public final class Baggage: @unchecked Sendable {
 	/// - Parameters:
 	///   - span: a parent span.
 	///   - subTraceId: an optional TraceId, overriding the parent span's, allowing for the creation of subtraces.
-	public init(span: Span, subTraceId: TraceId? = nil) {
+	///   - subtraceLinking: whether to link between subtrace and parent trace, and in which direction(s)
+	public init(span: Span, subTraceId: TraceId? = nil, subtraceLinking: SubtraceLinking = .bidirectional) {
 		self.span = span
 		self.subTraceId = subTraceId
+		self.subtraceLinking = subtraceLinking
 	}
 
 	// MARK: Internal
@@ -28,4 +41,5 @@ public final class Baggage: @unchecked Sendable {
 
 	let span: Span
 	let subTraceId: TraceId?
+	let subtraceLinking: SubtraceLinking
 }

--- a/Sources/NautilusTelemetry/Tracing/SpanLinkInternal.swift
+++ b/Sources/NautilusTelemetry/Tracing/SpanLinkInternal.swift
@@ -1,0 +1,4 @@
+// Created by Ladd Van Tol on 8/6/25.
+// Copyright © 2025 Airbnb Inc. All rights reserved.
+
+import Foundation

--- a/Sources/NautilusTelemetry/Tracing/SpanLinkInternal.swift
+++ b/Sources/NautilusTelemetry/Tracing/SpanLinkInternal.swift
@@ -1,4 +1,0 @@
-// Created by Ladd Van Tol on 8/6/25.
-// Copyright © 2025 Airbnb Inc. All rights reserved.
-
-import Foundation

--- a/Sources/NautilusTelemetry/Tracing/Tracer.swift
+++ b/Sources/NautilusTelemetry/Tracing/Tracer.swift
@@ -55,7 +55,11 @@ public final class Tracer {
 		baggage: Baggage? = nil
 	) -> Span {
 		let resolvedBaggage = baggage ?? currentBaggage
-		let subTraceBaggage = Baggage(span: resolvedBaggage.span, subTraceId: Identifiers.generateTraceId())
+		let subTraceBaggage = Baggage(
+			span: resolvedBaggage.span,
+			subTraceId: Identifiers.generateTraceId(),
+			subtraceLinking: resolvedBaggage.subtraceLinking
+		)
 		return startSpan(name: name, kind: kind, attributes: attributes, baggage: subTraceBaggage)
 	}
 
@@ -74,7 +78,11 @@ public final class Tracer {
 		block: () throws -> T
 	) rethrows -> T {
 		let resolvedBaggage = baggage ?? currentBaggage
-		let subTraceBaggage = Baggage(span: resolvedBaggage.span, subTraceId: Identifiers.generateTraceId())
+		let subTraceBaggage = Baggage(
+			span: resolvedBaggage.span,
+			subTraceId: Identifiers.generateTraceId(),
+			subtraceLinking: resolvedBaggage.subtraceLinking
+		)
 		return try withSpan(name: name, kind: kind, attributes: attributes, baggage: subTraceBaggage, block: block)
 	}
 
@@ -247,16 +255,32 @@ public final class Tracer {
 		let finalKind = (kind == .unspecified) ? resolvedBaggage.span.kind : kind // infer from parent span if unspecified
 
 		if let subTraceId = resolvedBaggage.subTraceId {
-			// Create a new detached trace with a link to the parent trace
-			return Span(
+			// Create a new detached trace with optional linking
+
+			let result = Span(
 				name: name,
 				kind: finalKind,
 				attributes: attributes,
 				traceId: subTraceId,
 				parentId: nil,
-				linkedParent: resolvedBaggage.span,
 				retireCallback: retire
 			)
+
+			let parent = resolvedBaggage.span
+
+			switch resolvedBaggage.subtraceLinking {
+			case .none:
+				break // no link needed
+			case .up:
+				result.addLink(parent, relationship: .parent)
+			case .down:
+				parent.addLink(result, relationship: .child)
+			case .bidirectional:
+				result.addLink(parent, relationship: .parent)
+				parent.addLink(result, relationship: .child)
+			}
+
+			return result
 		} else {
 			return Span(
 				name: name,

--- a/Sources/NautilusTelemetry/Tracing/Tracer.swift
+++ b/Sources/NautilusTelemetry/Tracing/Tracer.swift
@@ -268,15 +268,10 @@ public final class Tracer {
 
 			let parent = resolvedBaggage.span
 
-			switch resolvedBaggage.subtraceLinking {
-			case .none:
-				break // no link needed
-			case .up:
+			if resolvedBaggage.subtraceLinking.contains(.up) {
 				result.addLink(parent, relationship: .parent)
-			case .down:
-				parent.addLink(result, relationship: .child)
-			case .bidirectional:
-				result.addLink(parent, relationship: .parent)
+			}
+			if resolvedBaggage.subtraceLinking.contains(.down) {
 				parent.addLink(result, relationship: .child)
 			}
 

--- a/Tests/NautilusTelemetryTests/TraceExporterTests.swift
+++ b/Tests/NautilusTelemetryTests/TraceExporterTests.swift
@@ -47,7 +47,6 @@ final class TraceExporterTests: XCTestCase {
 	//  -p 9411:9411 \
 	//  cr.jaegertracing.io/jaegertracing/jaeger:2.9.0
 
-
 	let localEndpointBase = "http://localhost:4318"
 
 	static func testEnabled(_ name: String) -> Bool {


### PR DESCRIPTION
- Added more versatile subtrace linking options, defaulting to "bidirectional" (can be overridden via baggage)
- Updated tests
- Updated Jaeger instructions

These show up and are clickable, albeit without "parent/child" annotation in Jaeger:

<img width="1136" height="59" alt="Screenshot 2025-08-07 at 1 33 26 PM" src="https://github.com/user-attachments/assets/53ba19e0-efc3-49e1-b51b-de9aa28df705" />
<img width="1135" height="83" alt="Screenshot 2025-08-07 at 1 33 14 PM" src="https://github.com/user-attachments/assets/315063f2-1d39-4ed8-843f-6b1e07309d23" />


These show up and are **not** clickable in Grafana, although the attribute shows up:

<img width="816" height="39" alt="Screenshot 2025-08-07 at 2 13 25 PM" src="https://github.com/user-attachments/assets/7772b8fb-0ca0-428e-b939-44545d8d1ba5" />
<img width="973" height="37" alt="Screenshot 2025-08-07 at 2 12 58 PM" src="https://github.com/user-attachments/assets/445aafdf-b763-4897-aeb3-78d5574cfeb8" />


@jparise 
@bachand 