### PR TITLE
Add lock

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -18,5 +18,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+    - name: Set Xcode version
+      run: sudo xcode-select -s /Applications/Xcode_16.4.app
     - name: Build and run tests for the matrix
       run: xcodebuild ${{ matrix.xcodebuild-command }} -scheme NautilusTelemetry-Package -destination "${{ matrix.xcodebuild-destination }}"
+

--- a/README.md
+++ b/README.md
@@ -12,20 +12,17 @@ import NautilusTelemetry
 
 InstrumentationSystem.bootstrap(reporter: ExampleReporter())
 
-	func logResponseComplete() {
+	func example() {
 		let tracer = InstrumentationSystem.tracer
 		tracer.withSpan(name: #function) {
-			self.populateLogContext()
-			self.loggers.forEach { logger in
-				logger.logResponseComplete()
-			}
+			self.doWork()
 		}
 	}
 
 ```
 
 ## Contributing
-Pull requests are welcome. For major changes, please open an issue first to discuss what you would like to change.
+Pull requests are welcome. Please install [swiftformat](https://github.com/nicklockwood/SwiftFormat) and run `swiftformat .` manually before submitting a PR. For major changes, please open an issue first to discuss what you would like to change.
 
 Please make sure to update tests as appropriate.
 

--- a/Sources/NautilusTelemetry/Exporters/Exporter+Trace.swift
+++ b/Sources/NautilusTelemetry/Exporters/Exporter+Trace.swift
@@ -91,7 +91,9 @@ extension Exporter {
 	}
 
 	func buildLinks(_ span: Span) -> [OTLP.SpanLink]? {
-		span.links?.map { link in
+		guard span.links.count > 0 else { return nil }
+
+		return span.links.map { link in
 			let attributes: [OTLP.V1KeyValue]?
 			let key = "relationship"
 

--- a/Tests/NautilusTelemetryTests/SpanTests.swift
+++ b/Tests/NautilusTelemetryTests/SpanTests.swift
@@ -250,4 +250,12 @@ final class SpanTests: XCTestCase {
 		XCTAssertEqual(exceptionAttributes["exception.message"], "failure")
 	}
 
+	func test_concurrentAddLinks() throws {
+		let span = tracer.startSpan(name: "concurrentAddLinks")
+
+		DispatchQueue.concurrentPerform(iterations: 100) { _ in
+			let child = tracer.startSpan(name: "concurrentAddLinks")
+			span.addLink(child, relationship: .child)
+		}
+	}
 }

--- a/Tests/NautilusTelemetryTests/TracerTests.swift
+++ b/Tests/NautilusTelemetryTests/TracerTests.swift
@@ -1,0 +1,25 @@
+// Created by Ladd Van Tol on 8/25/25.
+// Copyright © 2025 Airbnb Inc. All rights reserved.
+
+import XCTest
+@testable import NautilusTelemetry
+
+final class TracerTests: XCTestCase {
+	let tracer = Tracer()
+
+	func testBuildSpanSubtraceLinking() {
+		let parent = tracer.startSpan(name: "parent")
+		let baggage = Baggage(span: parent, subTraceId: Identifiers.generateTraceId(), subtraceLinking: [.down, .up])
+
+		let child = tracer.buildSpan(name: "hello", kind: .client, attributes: nil, baggage: baggage)
+		XCTAssertEqual(child.links.count, 1)
+		XCTAssertEqual(child.links[0].relationship, .parent)
+		XCTAssertEqual(child.links[0].id, parent.id)
+		XCTAssertEqual(child.links[0].traceId, parent.traceId)
+
+		XCTAssertEqual(parent.links.count, 1)
+		XCTAssertEqual(parent.links[0].relationship, .child)
+		XCTAssertEqual(parent.links[0].id, child.id)
+		XCTAssertEqual(parent.links[0].traceId, child.traceId)
+	}
+}


### PR DESCRIPTION
- Fix a concurrent access issue in `addLink`. Use same lock to protect `addAttribute` and `addEvent`.
- Make `links` allocated in init, since it is commonly used now.
- Add tests.
- Improve `README.md`.


@bachand
