### PR TITLE
Add traceParentMode

### DIFF
--- a/Sources/NautilusTelemetry/Tracing/Tracer+URLRequest.swift
+++ b/Sources/NautilusTelemetry/Tracing/Tracer+URLRequest.swift
@@ -93,7 +93,7 @@ extension Tracer {
 		case .ifSampling:
 			span.addTraceHeadersIfSampling(&request, isSampling: isSampling)
 
-		case .unconditionally:
+		case .always:
 			span.addTraceHeadersUnconditionally(&request, isSampling: isSampling)
 		}
 

--- a/Sources/NautilusTelemetry/Tracing/Tracer+URLRequest.swift
+++ b/Sources/NautilusTelemetry/Tracing/Tracer+URLRequest.swift
@@ -26,7 +26,7 @@ extension Tracer {
 	) -> Span {
 		let name = Span.name(forRequest: request, target: template)
 		var span = startSpan(name: name, kind: .client, attributes: attributes, baggage: baggage)
-		Self.decorateSpan(
+		decorateSpan(
 			&span,
 			for: &request,
 			captureHeaders: captureHeaders,
@@ -55,7 +55,7 @@ extension Tracer {
 	) -> Span {
 		let name = Span.name(forRequest: request, target: template)
 		var span = startSubtraceSpan(name: name, kind: .client, attributes: attributes, baggage: baggage)
-		Self.decorateSpan(
+		decorateSpan(
 			&span,
 			for: &request,
 			captureHeaders: captureHeaders,
@@ -67,7 +67,7 @@ extension Tracer {
 
 	// MARK: Private
 
-	private static func decorateSpan(
+	private func decorateSpan(
 		_ span: inout Span,
 		for request: inout URLRequest,
 		captureHeaders: Set<String>? = nil,
@@ -86,7 +86,17 @@ extension Tracer {
 			span.addAttribute("url.template", template)
 		}
 
-		span.addTraceHeadersIfSampling(&request, isSampling: isSampling)
+		switch traceParentMode {
+		case .never:
+			break
+
+		case .ifSampling:
+			span.addTraceHeadersIfSampling(&request, isSampling: isSampling)
+
+		case .unconditionally:
+			span.addTraceHeadersUnconditionally(&request, isSampling: isSampling)
+		}
+
 		span.addHeaders(request: request, captureHeaders: captureHeaders)
 	}
 }

--- a/Sources/NautilusTelemetry/Tracing/Tracer.swift
+++ b/Sources/NautilusTelemetry/Tracing/Tracer.swift
@@ -21,9 +21,24 @@ public final class Tracer {
 
 	// MARK: Public
 
+	/// Controls when to set `traceparent` header on HTTP spans
+	public enum TraceParentMode {
+		/// Never set
+		case never
+
+		/// Only if sampling is enabled
+		case ifSampling
+
+		/// Always -- flag indicates sampling state
+		case unconditionally
+	}
+
 	/// Convenience to track the expected state of sampling
 	/// Traceparent headers use this by default
 	public var isSampling = false
+
+	/// Controls when to set `traceparent` header on HTTP spans
+	public var traceParentMode = TraceParentMode.unconditionally
 
 	/// Fetch the current span, using task local or thread local values, falling back to the root span.
 	public var currentSpan: Span { currentBaggage.span }

--- a/Sources/NautilusTelemetry/Tracing/Tracer.swift
+++ b/Sources/NautilusTelemetry/Tracing/Tracer.swift
@@ -30,7 +30,7 @@ public final class Tracer {
 		case ifSampling
 
 		/// Always -- flag indicates sampling state
-		case unconditionally
+		case always
 	}
 
 	/// Convenience to track the expected state of sampling
@@ -38,7 +38,7 @@ public final class Tracer {
 	public var isSampling = false
 
 	/// Controls when to set `traceparent` header on HTTP spans
-	public var traceParentMode = TraceParentMode.unconditionally
+	public var traceParentMode = TraceParentMode.always
 
 	/// Fetch the current span, using task local or thread local values, falling back to the root span.
 	public var currentSpan: Span { currentBaggage.span }

--- a/Tests/NautilusTelemetryTests/Tracer+URLRequestTests.swift
+++ b/Tests/NautilusTelemetryTests/Tracer+URLRequestTests.swift
@@ -103,7 +103,7 @@ final class TracerURLRequestTests: XCTestCase {
 	}
 
 	func testTraceParentModeUnconditionallyWhenSampled() throws {
-		tracer.traceParentMode = .unconditionally
+		tracer.traceParentMode = .always
 		tracer.isSampling = true
 
 		let url = try makeURL("/")
@@ -117,7 +117,7 @@ final class TracerURLRequestTests: XCTestCase {
 	}
 
 	func testTraceParentModeUnconditionallyWhenNotSampled() throws {
-		tracer.traceParentMode = .unconditionally
+		tracer.traceParentMode = .always
 		tracer.isSampling = false
 
 		let url = try makeURL("/")
@@ -145,6 +145,6 @@ final class TracerURLRequestTests: XCTestCase {
 	}
 
 	func testTraceParentModeDefaultValue() {
-		XCTAssertEqual(tracer.traceParentMode, .unconditionally)
+		XCTAssertEqual(tracer.traceParentMode, .always)
 	}
 }

--- a/Tests/NautilusTelemetryTests/Tracer+URLRequestTests.swift
+++ b/Tests/NautilusTelemetryTests/Tracer+URLRequestTests.swift
@@ -61,4 +61,90 @@ final class TracerURLRequestTests: XCTestCase {
 		let (headerName, headerValue) = span.traceParentHeaderValue(sampled: true)
 		XCTAssertEqual(urlRequest.value(forHTTPHeaderField: headerName), headerValue)
 	}
+
+	func testTraceParentModeNever() throws {
+		tracer.traceParentMode = .never
+		tracer.isSampling = true
+
+		let url = try makeURL("/")
+		var urlRequest = URLRequest(url: url)
+		let span = tracer.startSpan(request: &urlRequest)
+
+		XCTAssertNil(urlRequest.value(forHTTPHeaderField: "traceparent"))
+
+		span.end()
+	}
+
+	func testTraceParentModeIfSamplingSampled() throws {
+		tracer.traceParentMode = .ifSampling
+		tracer.isSampling = true
+
+		let url = try makeURL("/")
+		var urlRequest = URLRequest(url: url)
+		let span = tracer.startSpan(request: &urlRequest)
+
+		let (headerName, headerValue) = span.traceParentHeaderValue(sampled: true)
+		XCTAssertEqual(urlRequest.value(forHTTPHeaderField: headerName), headerValue)
+
+		span.end()
+	}
+
+	func testTraceParentModeIfSamplingNotSampled() throws {
+		tracer.traceParentMode = .ifSampling
+		tracer.isSampling = false
+
+		let url = try makeURL("/")
+		var urlRequest = URLRequest(url: url)
+		let span = tracer.startSpan(request: &urlRequest)
+
+		XCTAssertNil(urlRequest.value(forHTTPHeaderField: "traceparent"))
+
+		span.end()
+	}
+
+	func testTraceParentModeUnconditionallyWhenSampled() throws {
+		tracer.traceParentMode = .unconditionally
+		tracer.isSampling = true
+
+		let url = try makeURL("/")
+		var urlRequest = URLRequest(url: url)
+		let span = tracer.startSpan(request: &urlRequest)
+
+		let (headerName, headerValue) = span.traceParentHeaderValue(sampled: true)
+		XCTAssertEqual(urlRequest.value(forHTTPHeaderField: headerName), headerValue)
+
+		span.end()
+	}
+
+	func testTraceParentModeUnconditionallyWhenNotSampled() throws {
+		tracer.traceParentMode = .unconditionally
+		tracer.isSampling = false
+
+		let url = try makeURL("/")
+		var urlRequest = URLRequest(url: url)
+		let span = tracer.startSpan(request: &urlRequest)
+
+		let (headerName, headerValue) = span.traceParentHeaderValue(sampled: false)
+		XCTAssertEqual(urlRequest.value(forHTTPHeaderField: headerName), headerValue)
+
+		span.end()
+	}
+
+	func testTraceParentModeWithSubtraceSpan() throws {
+		tracer.traceParentMode = .ifSampling
+		tracer.isSampling = true
+
+		let url = try makeURL("/")
+		var urlRequest = URLRequest(url: url)
+		let span = tracer.startSubtraceSpan(request: &urlRequest)
+
+		let (headerName, headerValue) = span.traceParentHeaderValue(sampled: true)
+		XCTAssertEqual(urlRequest.value(forHTTPHeaderField: headerName), headerValue)
+
+		span.end()
+	}
+
+	func testTraceParentModeDefaultValue() {
+		XCTAssertEqual(tracer.traceParentMode, .unconditionally)
+	}
 }


### PR DESCRIPTION
- Add `traceParentMode` controlling when we add `traceparent` header.
- Default this to unconditionally -- previously we did this only when sampling. This coordinates better with internal thinking on how best to handle traceparent & the sampling flag.
- Add tests.

@jparise 
@bachand