### PR TITLE
Make NetworkMonitor public

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.8
+// swift-tools-version:5.9
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 // Copyright © 2021 eBay. All rights reserved.
 

--- a/Sources/NautilusTelemetry/Instrumentation/NetworkMonitor.swift
+++ b/Sources/NautilusTelemetry/Instrumentation/NetworkMonitor.swift
@@ -8,11 +8,15 @@ import Synchronization
 
 // MARK: - NetworkMonitor
 
-final class NetworkMonitor {
+public final class NetworkMonitor {
 
-	// MARK: Internal
+	// MARK: Lifecycle
 
-	var attributes: TelemetryAttributes {
+	public init() { }
+
+	// MARK: Public
+
+	public var attributes: TelemetryAttributes {
 		var attributes = TelemetryAttributes()
 
 		if let networkPath = networkPath.withLock({ $0 }) {
@@ -39,17 +43,19 @@ final class NetworkMonitor {
 		return attributes
 	}
 
-	func start() {
+	public func start() {
 		pathMonitor.pathUpdateHandler = { [weak self] path in
 			self?.networkPath.withLock { $0 = path }
 		}
 		pathMonitor.start(queue: pathMonitorQueue)
 	}
 
-	func stop() {
+	public func stop() {
 		pathMonitor.cancel()
 		networkPath.withLock { $0 = nil }
 	}
+
+	// MARK: Internal
 
 	#if os(iOS)
 	func radioAccessTechnologyDescription(_ technology: String) -> String {


### PR DESCRIPTION
Sorry for the churn -- I failed to make NetworkMonitor public as I intended.

Also updates Swift version to 5.9 -- not quite ready to tackle concurrency requirements in 6.0.

@jparise
@bachand