### PR TITLE
Add span-level sample rate override

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -41,7 +41,7 @@ let package = Package(
 		),
 		.testTarget(
 			name: "NautilusTelemetryTests",
-			dependencies: ["NautilusTelemetry"],
+			dependencies: ["NautilusTelemetry", "SampleCode"],
 			swiftSettings: [
 				.enableUpcomingFeature("BareSlashRegexLiterals"),
 			]

--- a/Sources/NautilusTelemetry/Tracing/Span.swift
+++ b/Sources/NautilusTelemetry/Tracing/Span.swift
@@ -54,7 +54,8 @@ public final class Span: TelemetryAttributesContainer, Identifiable {
 		parentId: SpanId?,
 		links: [Link] = [Link](),
 		retireCallback: ((_: Span) -> Void)? = nil,
-		isRoot: Bool = false
+		isRoot: Bool = false,
+		sampleRate: Double? = nil
 	) {
 		self.name = name
 		self.kind = kind
@@ -67,6 +68,7 @@ public final class Span: TelemetryAttributesContainer, Identifiable {
 		self.endTime = endTime
 		self.retireCallback = retireCallback
 		self.isRoot = isRoot
+		self.sampleRate = sampleRate
 
 		addDefaultAttributes()
 	}
@@ -100,6 +102,11 @@ public final class Span: TelemetryAttributesContainer, Identifiable {
 	public let traceId: TraceId
 	public let id: SpanId
 	public let isRoot: Bool
+
+	/// Allows overriding the default sample rate for this span and its children.
+	/// Expressed as a percentage in the 0-100 range.
+	/// USE WITH CAUTION.
+	public var sampleRate: Double?
 
 	public var ended: Bool {
 		endTime != nil

--- a/Sources/NautilusTelemetry/Tracing/Tracer.swift
+++ b/Sources/NautilusTelemetry/Tracing/Tracer.swift
@@ -317,7 +317,8 @@ public final class Tracer {
 				attributes: mergedAttributes,
 				traceId: subTraceId,
 				parentId: nil,
-				retireCallback: retire
+				retireCallback: retire,
+				sampleRate: resolvedBaggage.span.sampleRate
 			)
 
 			let parent = resolvedBaggage.span
@@ -337,7 +338,8 @@ public final class Tracer {
 				attributes: mergedAttributes,
 				traceId: resolvedBaggage.span.traceId,
 				parentId: resolvedBaggage.span.id,
-				retireCallback: retire
+				retireCallback: retire,
+				sampleRate: resolvedBaggage.span.sampleRate
 			)
 		}
 	}

--- a/Sources/SampleCode/ExampleReporter.swift
+++ b/Sources/SampleCode/ExampleReporter.swift
@@ -48,14 +48,13 @@ public class ExampleReporter: NautilusTelemetryReporter {
 	}
 
 	public func reportSpans(_ spans: [Span]) {
-		guard Self.samplingEnabled else {
-			return
-		}
+		let filtered = sampledSpans(spans)
+		guard !filtered.isEmpty else { return }
 
 		let additionalAttributes = ["sample": "value"]
 		let exporter = Exporter(timeReference: timeReference)
 
-		if let jsonPayload = try? exporter.exportOTLPToJSON(spans: spans, additionalAttributes: additionalAttributes) {
+		if let jsonPayload = try? exporter.exportOTLPToJSON(spans: filtered, additionalAttributes: additionalAttributes) {
 			try? dispatchPayload(jsonPayload: jsonPayload, url: traceEndpoint)
 		}
 	}
@@ -88,7 +87,8 @@ public class ExampleReporter: NautilusTelemetryReporter {
 		return "\(bundleIdentifier)/\(bundleVersion)"
 	}()
 
-	static let sampler = StableGuidSampler(sampleRate: 1.0, seed: Data("OpenTelemetry".utf8), guid: sessionGUID)
+	static let samplerSeed = Data("OpenTelemetry".utf8)
+	static let sampler = StableGuidSampler(sampleRate: 1.0, seed: samplerSeed, guid: sessionGUID)
 
 	static var sessionGUID: Data {
 		lock.withLock {
@@ -121,6 +121,16 @@ public class ExampleReporter: NautilusTelemetryReporter {
 	static func resetSessionGUID() {
 		lock.withLock {
 			_sessionGUID = nil
+		}
+	}
+
+	/// Filters spans based on their sample rate override, falling back to `Self.samplingEnabled` when unset.
+	func sampledSpans(_ spans: [Span]) -> [Span] {
+		spans.filter { span in
+			if let sampleRate = span.sampleRate {
+				return StableGuidSampler(sampleRate: sampleRate, seed: Self.samplerSeed, guid: Self.sessionGUID).shouldSample
+			}
+			return Self.samplingEnabled
 		}
 	}
 

--- a/Tests/NautilusTelemetryTests/Reporters/ExampleReporterTests.swift
+++ b/Tests/NautilusTelemetryTests/Reporters/ExampleReporterTests.swift
@@ -1,0 +1,38 @@
+// Created by Ladd Van Tol on 2026-04-16.
+
+import Testing
+@testable import NautilusTelemetry
+@testable import SampleCode
+
+@Suite
+struct ExampleReporterTests {
+
+	let reporter = ExampleReporter()
+	let tracer = Tracer()
+
+	@Test("Spans without sampleRate fall back to global sampling")
+	func sampledSpans_noOverride_usesGlobalSampling() {
+		let span = tracer.startSpan(name: "test")
+		#expect(span.sampleRate == nil)
+
+		let result = reporter.sampledSpans([span])
+		#expect(result.count == (ExampleReporter.samplingEnabled ? 1 : 0))
+	}
+
+	@Test("Spans with sampleRate 100 are always included")
+	func sampledSpans_overrideAt100_alwaysIncluded() {
+		let span = tracer.startSpan(name: "always")
+		span.sampleRate = 100.0
+
+		#expect(reporter.sampledSpans([span]).count == 1)
+	}
+
+	@Test("Spans with sampleRate 0 are always excluded")
+	func sampledSpans_overrideAt0_alwaysExcluded() {
+		let span = tracer.startSpan(name: "never")
+		span.sampleRate = 0.0
+
+		#expect(reporter.sampledSpans([span]).count == 0)
+	}
+
+}

--- a/Tests/NautilusTelemetryTests/Tracing/SpanTests.swift
+++ b/Tests/NautilusTelemetryTests/Tracing/SpanTests.swift
@@ -6,31 +6,28 @@
 //
 
 import Foundation
-import XCTest
+import Testing
 
 @testable import NautilusTelemetry
 
-final class SpanTests: XCTestCase {
+@Suite
+struct SpanTests {
 
 	enum TestError: Error {
 		case failure
 	}
 
 	let tracer = Tracer()
-
 	let iterations = 100
 
 	let traceParentValueRegex_Sampling = /00-[a-f0-9]{32}-[a-f0-9]{16}-01/
 	let traceParentValueRegex_NotSampling = /00-[a-f0-9]{32}-[a-f0-9]{16}-00/
 
-	override func tearDown() {
-		tracer.flushRetiredSpans()
-	}
-
-	func testTraceId() {
+	@Test
+	func traceId() {
 		let traceId = Identifiers.generateTraceId()
-		XCTAssertEqual(traceId.count, 16)
-		XCTAssertNotEqual(traceId, Data(repeating: 0, count: 16))
+		#expect(traceId.count == 16)
+		#expect(traceId != Data(repeating: 0, count: 16))
 
 		let serial = DispatchQueue(label: "serial")
 		var set = Set<Data>()
@@ -40,13 +37,14 @@ final class SpanTests: XCTestCase {
 			_ = serial.sync { set.insert(traceId) }
 		}
 
-		XCTAssert(set.count == iterations) // check for duplicates
+		#expect(set.count == iterations)
 	}
 
-	func testSpanId() {
+	@Test
+	func spanId() {
 		let spanId = Identifiers.generateSpanId()
-		XCTAssertEqual(spanId.count, 8)
-		XCTAssertNotEqual(spanId, Data(repeating: 0, count: 8))
+		#expect(spanId.count == 8)
+		#expect(spanId != Data(repeating: 0, count: 8))
 
 		let serial = DispatchQueue(label: "serial")
 		var set = Set<Data>()
@@ -56,130 +54,119 @@ final class SpanTests: XCTestCase {
 			_ = serial.sync { set.insert(traceId) }
 		}
 
-		XCTAssert(set.count == iterations) // check for duplicates
+		#expect(set.count == iterations)
 	}
 
-	func testTrace() throws {
-		// we expect this test to run on main queue
-		dispatchPrecondition(condition: .onQueue(DispatchQueue.main))
-
+	@Test
+	func trace() throws {
 		try tracer.withSpan(name: "span1") {
-			XCTAssert(tracer.currentBaggage.span.parentId != nil)
+			#expect(tracer.currentBaggage.span.parentId != nil)
 			try span2Run()
 			tracer.currentSpan.addEvent(Span.Event(name: "event1"))
 		}
 
-		XCTAssert(tracer.retiredSpans.count == 2)
+		#expect(tracer.retiredSpans.count == 2)
 
 		let span2 = tracer.retiredSpans[0]
-		XCTAssert(span2.events?.count == 2)
-		XCTAssert(span2.status == .ok)
+		#expect(span2.events?.count == 2)
+		#expect(span2.status == .ok)
 
 		let traceParentHeader = span2.traceParentHeaderValue(sampled: true)
-		XCTAssertEqual(traceParentHeader.0, "traceparent")
-
-		XCTAssert(try traceParentValueRegex_Sampling.wholeMatch(in: traceParentHeader.1) != nil)
+		#expect(traceParentHeader.0 == "traceparent")
+		#expect(try traceParentValueRegex_Sampling.wholeMatch(in: traceParentHeader.1) != nil)
 	}
 
-	func testTraceWithError() throws {
-		// we expect this test to run on main queue
-		dispatchPrecondition(condition: .onQueue(DispatchQueue.main))
-
+	@Test
+	func traceWithError() throws {
 		try tracer.withSpan(name: "span1") {
-			XCTAssert(tracer.currentBaggage.span.parentId != nil)
+			#expect(tracer.currentBaggage.span.parentId != nil)
 			try span2Run()
 			tracer.currentSpan.recordError(TestError.failure, includeBacktrace: true)
 			tracer.currentSpan.addEvent(Span.Event(name: "event1"))
 		}
 
-		XCTAssert(tracer.retiredSpans.count == 2)
+		#expect(tracer.retiredSpans.count == 2)
 
 		let span2 = tracer.retiredSpans[0]
-		XCTAssert(span2.events?.count == 2)
-		XCTAssert(span2.status == .ok)
+		#expect(span2.events?.count == 2)
+		#expect(span2.status == .ok)
 
 		let span1 = tracer.retiredSpans[1]
-		XCTAssertEqual(
-			span1.status,
-			.error(message: "failure")
-		)
+		#expect(span1.status == .error(message: "failure"))
 
-		let exceptionType = try XCTUnwrap(span1.events?[0].attributes?["exception.type"])
-		XCTAssertEqual(exceptionType, "NautilusTelemetryTests.SpanTests.TestError")
+		let exceptionType = try #require(span1.events?[0].attributes?["exception.type"] as? String)
+		#expect(exceptionType == "NautilusTelemetryTests.SpanTests.TestError")
 
 		let event = span1.events?[0]
-		let backtrace = try XCTUnwrap(event?.attributes?["exception.stacktrace"] as? String)
-
-		XCTAssert(backtrace.contains("testTraceWithError"))
+		let backtrace = try #require(event?.attributes?["exception.stacktrace"] as? String)
+		#expect(backtrace.contains("traceWithError"))
 
 		let traceParentHeader = span2.traceParentHeaderValue(sampled: false)
-		XCTAssertEqual(traceParentHeader.0, "traceparent")
-		XCTAssert(try traceParentValueRegex_NotSampling.wholeMatch(in: traceParentHeader.1) != nil)
+		#expect(traceParentHeader.0 == "traceparent")
+		#expect(try traceParentValueRegex_NotSampling.wholeMatch(in: traceParentHeader.1) != nil)
 	}
 
-	func testTraceparentHeader() throws {
-		let url = try makeURL("https://api.example.com/")
+	@Test
+	func traceparentHeader() throws {
+		let url = try TestUtils.makeURL("https://api.example.com/")
 		let span = tracer.startSpan(name: "test")
 
 		do {
 			var urlRequest = URLRequest(url: url)
 			span.addTraceHeadersIfSampling(&urlRequest, isSampling: true)
-			let header = try XCTUnwrap(urlRequest.value(forHTTPHeaderField: "traceparent"))
-			XCTAssert(try traceParentValueRegex_Sampling.wholeMatch(in: header) != nil)
+			let header = try #require(urlRequest.value(forHTTPHeaderField: "traceparent"))
+			#expect(try traceParentValueRegex_Sampling.wholeMatch(in: header) != nil)
 		}
 
 		do {
 			var urlRequest = URLRequest(url: url)
 			let span = tracer.startSpan(name: "test")
 			span.addTraceHeadersIfSampling(&urlRequest, isSampling: false)
-			XCTAssertNil(urlRequest.value(forHTTPHeaderField: "traceparent"))
+			#expect(urlRequest.value(forHTTPHeaderField: "traceparent") == nil)
 		}
 
 		do {
 			var urlRequest = URLRequest(url: url)
 			span.addTraceHeadersUnconditionally(&urlRequest, isSampling: true)
-			let header = try XCTUnwrap(urlRequest.value(forHTTPHeaderField: "traceparent"))
-			XCTAssert(try traceParentValueRegex_Sampling.wholeMatch(in: header) != nil)
+			let header = try #require(urlRequest.value(forHTTPHeaderField: "traceparent"))
+			#expect(try traceParentValueRegex_Sampling.wholeMatch(in: header) != nil)
 		}
 
 		do {
 			var urlRequest = URLRequest(url: url)
 			span.addTraceHeadersUnconditionally(&urlRequest, isSampling: false)
-			let header = try XCTUnwrap(urlRequest.value(forHTTPHeaderField: "traceparent"))
-			XCTAssert(try traceParentValueRegex_NotSampling.wholeMatch(in: header) != nil)
+			let header = try #require(urlRequest.value(forHTTPHeaderField: "traceparent"))
+			#expect(try traceParentValueRegex_NotSampling.wholeMatch(in: header) != nil)
 		}
 	}
 
-	func testThrowing() throws {
-		// we expect this test to run on main queue
-		dispatchPrecondition(condition: .onQueue(DispatchQueue.main))
-
-		do {
+	@Test
+	func throwingSpan() throws {
+		#expect(throws: TestError.self) {
 			try tracer.withSpan(name: "span1") {
 				throw TestError.failure
 			}
-		} catch { }
-
-		XCTAssert(tracer.retiredSpans.count == 1)
-
-		let span1 = tracer.retiredSpans[0]
-		XCTAssert(span1.status != .ok)
-	}
-
-	#if compiler(>=5.6.0) && canImport(_Concurrency)
-	func testAsync() async throws {
-		try await tracer.withSpan(name: "span1") {
-			XCTAssert(tracer.currentBaggage.span.parentId != nil)
-			try await span2RunAsync()
 		}
 
-		XCTAssert(tracer.retiredSpans.count == 2)
+		#expect(tracer.retiredSpans.count == 1)
+
+		let span1 = tracer.retiredSpans[0]
+		#expect(span1.status != .ok)
+	}
+
+	@Test
+	func asyncSpan() async throws {
+		try await tracer.withSpan(name: "span1") {
+			#expect(tracer.currentBaggage.span.parentId != nil)
+			try span2Run()
+		}
+
+		#expect(tracer.retiredSpans.count == 2)
 
 		let span2 = tracer.retiredSpans[0]
-		XCTAssert(span2.events?.count == 2)
-		XCTAssert(span2.status == .ok)
+		#expect(span2.events?.count == 2)
+		#expect(span2.status == .ok)
 	}
-	#endif
 
 	func span2Run() throws {
 		var ranSpan = false
@@ -191,77 +178,74 @@ final class SpanTests: XCTestCase {
 			span.status = .ok
 			ranSpan = true
 		}
-
-		XCTAssert(ranSpan)
+		#expect(ranSpan)
 	}
 
-	func span2RunAsync() async throws {
-		var ranSpan = false
-		tracer.withSpan(name: "span2async") {
-			let span = tracer.currentBaggage.span
-			span.addEvent("event1")
-			Thread.sleep(forTimeInterval: 0.1)
-			span.addEvent("event2")
-			span.status = .ok
-			ranSpan = true
+	@Test
+	func memoryLeaks() {
+		weak var weakSpan1: Span?
+		weak var weakSpan2: Span?
+
+		autoreleasepool {
+			let span1 = tracer.startSpan(name: "span1")
+			weakSpan1 = span1
+
+			tracer.withSpan(name: "span2") {
+				let span2 = tracer.currentBaggage.span
+				weakSpan2 = span2
+				span2.addEvent("event1")
+				Thread.sleep(forTimeInterval: 0.1)
+				span2.addEvent("event2")
+				span2.status = .ok
+			}
+
+			tracer.flushRetiredSpans()
 		}
 
-		XCTAssert(ranSpan)
+		#expect(weakSpan1 == nil)
+		#expect(weakSpan2 == nil)
 	}
 
-	func testForMemoryLeaks() throws {
-		let span1 = tracer.startSpan(name: "span1")
-		trackForMemoryLeak(instance: span1)
-
-		tracer.withSpan(name: "span2") {
-			let span2 = tracer.currentBaggage.span
-			span2.addEvent("event1")
-			Thread.sleep(forTimeInterval: 0.1)
-			span2.addEvent("event2")
-			span2.status = .ok
-
-			trackForMemoryLeak(instance: span2)
-		}
-
-		tracer.flushRetiredSpans() // make sure retired spans don't show up as leaks
-	}
-
-	func test_recordNSError() throws {
+	@Test
+	func recordNSError() throws {
 		let span = tracer.startSpan(name: "errorSpan")
 		let error = NSError(domain: "VeryBadError", code: -42, userInfo: [NSLocalizedDescriptionKey: "NSFailed"])
 		span.recordError(error)
 
-		let exceptionEvent = try XCTUnwrap(span.events?.first)
-		let exceptionAttributes = try XCTUnwrap(exceptionEvent.attributes)
-		XCTAssertEqual(span.status, .error(message: "NSFailed"))
-		XCTAssertEqual(exceptionAttributes["exception.type"], "NSError.VeryBadError.-42")
-		XCTAssertEqual(exceptionAttributes["exception.message"], "NSFailed")
+		let exceptionEvent = try #require(span.events?.first)
+		let exceptionAttributes = try #require(exceptionEvent.attributes)
+		#expect(span.status == .error(message: "NSFailed"))
+		#expect(exceptionAttributes["exception.type"] as? String == "NSError.VeryBadError.-42")
+		#expect(exceptionAttributes["exception.message"] as? String == "NSFailed")
 	}
 
-	func test_recordError() throws {
+	@Test
+	func recordError() throws {
 		let error = TestError.failure
 		let span = tracer.startSpan(name: "errorSpan")
 		span.recordError(error)
 
-		let exceptionEvent = try XCTUnwrap(span.events?.first)
-		let exceptionAttributes = try XCTUnwrap(exceptionEvent.attributes)
-		XCTAssertEqual(span.status, .error(message: "failure"))
-		XCTAssertEqual(exceptionAttributes["exception.type"], "NautilusTelemetryTests.SpanTests.TestError")
-		XCTAssertEqual(exceptionAttributes["exception.message"], "failure")
+		let exceptionEvent = try #require(span.events?.first)
+		let exceptionAttributes = try #require(exceptionEvent.attributes)
+		#expect(span.status == .error(message: "failure"))
+		#expect(exceptionAttributes["exception.type"] as? String == "NautilusTelemetryTests.SpanTests.TestError")
+		#expect(exceptionAttributes["exception.message"] as? String == "failure")
 	}
 
-	func test_recordErrorWithMessage() throws {
+	@Test
+	func recordErrorWithMessage() throws {
 		let span = tracer.startSpan(name: "errorSpan")
 		span.recordError(withType: "custom", message: "custom error message")
 
-		let exceptionEvent = try XCTUnwrap(span.events?.first)
-		let exceptionAttributes = try XCTUnwrap(exceptionEvent.attributes)
-		XCTAssertEqual(span.status, .error(message: "custom error message"))
-		XCTAssertEqual(exceptionAttributes["exception.type"], "custom")
-		XCTAssertEqual(exceptionAttributes["exception.message"], "custom error message")
+		let exceptionEvent = try #require(span.events?.first)
+		let exceptionAttributes = try #require(exceptionEvent.attributes)
+		#expect(span.status == .error(message: "custom error message"))
+		#expect(exceptionAttributes["exception.type"] as? String == "custom")
+		#expect(exceptionAttributes["exception.message"] as? String == "custom error message")
 	}
 
-	func test_concurrentAddLinks() throws {
+	@Test
+	func concurrentAddLinks() {
 		let span = tracer.startSpan(name: "concurrentAddLinks")
 
 		DispatchQueue.concurrentPerform(iterations: 100) { _ in
@@ -270,36 +254,37 @@ final class SpanTests: XCTestCase {
 		}
 	}
 
-	func testSpanIsRootDefaultValue() {
+	@Test
+	func spanIsRootDefaultValue() {
 		let traceId = Identifiers.generateTraceId()
 		let span = Span(name: "test", kind: .internal, traceId: traceId, parentId: nil)
-
-		XCTAssertFalse(span.isRoot)
+		#expect(span.isRoot == false)
 	}
 
-	func testSpanIsRootExplicitlySetToTrue() {
+	@Test
+	func spanIsRootExplicitlySetToTrue() {
 		let traceId = Identifiers.generateTraceId()
 		let span = Span(name: "test", kind: .internal, traceId: traceId, parentId: nil, isRoot: true)
-
-		XCTAssertTrue(span.isRoot)
+		#expect(span.isRoot == true)
 	}
 
-	func testSpanIsRootExplicitlySetToFalse() {
+	@Test
+	func spanIsRootExplicitlySetToFalse() {
 		let traceId = Identifiers.generateTraceId()
 		let span = Span(name: "test", kind: .internal, traceId: traceId, parentId: nil, isRoot: false)
-
-		XCTAssertFalse(span.isRoot)
+		#expect(span.isRoot == false)
 	}
 
-	func testNonRootSpanHasIsRootFalse() {
+	@Test
+	func nonRootSpanHasIsRootFalse() {
 		let traceId = Identifiers.generateTraceId()
 		let parentId = Identifiers.generateSpanId()
 		let span = Span(name: "child", kind: .internal, traceId: traceId, parentId: parentId)
-
-		XCTAssertFalse(span.isRoot)
+		#expect(span.isRoot == false)
 	}
 
-	func testOverlapsInterval() {
+	@Test
+	func overlapsInterval() {
 		let traceId = Identifiers.generateTraceId()
 		let t = ContinuousClock.now
 
@@ -310,50 +295,59 @@ final class SpanTests: XCTestCase {
 		let span = makeSpan(start: .seconds(2), end: .seconds(4))
 
 		// Overlapping cases
-		XCTAssertTrue(span.overlapsInterval(t + .seconds(1), t + .seconds(5)), "interval encompasses span")
-		XCTAssertTrue(span.overlapsInterval(t + .seconds(3), t + .seconds(3)), "span encompasses interval")
-		XCTAssertTrue(span.overlapsInterval(t + .seconds(1), t + .seconds(3)), "overlap at start")
-		XCTAssertTrue(span.overlapsInterval(t + .seconds(3), t + .seconds(5)), "overlap at end")
-		XCTAssertTrue(span.overlapsInterval(t + .seconds(2), t + .seconds(4)), "exact match")
-		XCTAssertTrue(span.overlapsInterval(t + .seconds(4), t + .seconds(5)), "shared endpoint")
+		#expect(span.overlapsInterval(t + .seconds(1), t + .seconds(5)), "interval encompasses span")
+		#expect(span.overlapsInterval(t + .seconds(3), t + .seconds(3)), "span encompasses interval")
+		#expect(span.overlapsInterval(t + .seconds(1), t + .seconds(3)), "overlap at start")
+		#expect(span.overlapsInterval(t + .seconds(3), t + .seconds(5)), "overlap at end")
+		#expect(span.overlapsInterval(t + .seconds(2), t + .seconds(4)), "exact match")
+		#expect(span.overlapsInterval(t + .seconds(4), t + .seconds(5)), "shared endpoint")
 
 		// Non-overlapping cases
-		XCTAssertFalse(span.overlapsInterval(t + .seconds(0), t + .seconds(1)), "entirely before")
-		XCTAssertFalse(span.overlapsInterval(t + .seconds(5), t + .seconds(6)), "entirely after")
+		#expect(!span.overlapsInterval(t + .seconds(0), t + .seconds(1)), "entirely before")
+		#expect(!span.overlapsInterval(t + .seconds(5), t + .seconds(6)), "entirely after")
 	}
 
-	func testSpanSubscript() {
+	@Test
+	func spanSubscript() {
 		let span = tracer.startSpan(name: "test")
 		span["key1"] = "value1"
-		XCTAssertEqual(span["key1"], "value1")
+		#expect(span["key1"] as? String == "value1")
 	}
 
-	func test_adjust() {
+	@Test
+	func sampleRate() {
+		let traceId = Identifiers.generateTraceId()
+		#expect(Span(name: "test", traceId: traceId, parentId: nil).sampleRate == nil)
+		#expect(Span(name: "test", traceId: traceId, parentId: nil, sampleRate: 50.0).sampleRate == 50.0)
+	}
+
+	@Test
+	func adjust() {
 		let traceId = Identifiers.generateTraceId()
 		let t = ContinuousClock.now
 
 		// start only
 		let span1 = Span(name: "test", startTime: t, endTime: t + .seconds(10), traceId: traceId, parentId: nil)
 		span1.adjust(start: .seconds(2))
-		XCTAssertEqual(span1.startTime, t + .seconds(2))
-		XCTAssertEqual(span1.endTime, t + .seconds(10))
+		#expect(span1.startTime == t + .seconds(2))
+		#expect(span1.endTime == t + .seconds(10))
 
 		// end only
 		let span2 = Span(name: "test", startTime: t, endTime: t + .seconds(10), traceId: traceId, parentId: nil)
 		span2.adjust(end: .seconds(3))
-		XCTAssertEqual(span2.startTime, t)
-		XCTAssertEqual(span2.endTime, t + .seconds(13))
+		#expect(span2.startTime == t)
+		#expect(span2.endTime == t + .seconds(13))
 
 		// both start and end
 		let span3 = Span(name: "test", startTime: t, endTime: t + .seconds(10), traceId: traceId, parentId: nil)
 		span3.adjust(start: .seconds(-1), end: .seconds(-2))
-		XCTAssertEqual(span3.startTime, t - .seconds(1))
-		XCTAssertEqual(span3.endTime, t + .seconds(8))
+		#expect(span3.startTime == t - .seconds(1))
+		#expect(span3.endTime == t + .seconds(8))
 
 		// nil endTime is unaffected
 		let span4 = Span(name: "test", startTime: t, traceId: traceId, parentId: nil)
 		span4.adjust(start: .seconds(5), end: .seconds(5))
-		XCTAssertEqual(span4.startTime, t + .seconds(5))
-		XCTAssertNil(span4.endTime)
+		#expect(span4.startTime == t + .seconds(5))
+		#expect(span4.endTime == nil)
 	}
 }

--- a/Tests/NautilusTelemetryTests/Tracing/TracerTests.swift
+++ b/Tests/NautilusTelemetryTests/Tracing/TracerTests.swift
@@ -1,212 +1,218 @@
 // Created by Ladd Van Tol on 8/25/25.
 // Copyright © 2025 Airbnb Inc. All rights reserved.
 
-import XCTest
+import Foundation
+import Synchronization
+import Testing
 @testable import NautilusTelemetry
 
-final class TracerTests: XCTestCase {
-	class TestReporter: NautilusTelemetryReporter {
-
-		// MARK: Lifecycle
-
-		init(
-			_ test: XCTestCase,
-			idleExpectation: XCTestExpectation
-		) {
-			self.test = test
-			self.idleExpectation = idleExpectation
-		}
-
-		// MARK: Internal
-
-		let test: XCTestCase
-		let idleExpectation: XCTestExpectation
-
-		/// Shorten the idle timeout for the test
-		var idleTimeoutInterval: TimeInterval { 0.1 }
-
-		func reportSpans(_: [Span]) { }
-
-		func reportInstruments(_: [any Instrument]) { }
-
-		func subscribeToLifecycleEvents() { }
-
-		func idleTimeout() {
-			// Turn off the timer
-			InstrumentationSystem.tracer.flushTimer?.suspend()
-			idleExpectation.fulfill()
-		}
-	}
+@Suite
+struct TracerTests {
 
 	let tracer = Tracer()
 
-	func testBuildSpanSubtraceLinking() {
+	@Test
+	func buildSpanSubtraceLinking() {
 		let parent = tracer.startSpan(name: "parent")
 		let baggage = Baggage(span: parent, subTraceId: Identifiers.generateTraceId(), subtraceLinking: [.down, .up])
 
 		let child = tracer.buildSpan(name: "hello", kind: .client, attributes: nil, baggage: baggage)
-		XCTAssertEqual(child.links.count, 1)
-		XCTAssertEqual(child.links[0].relationship, .parent)
-		XCTAssertEqual(child.links[0].id, parent.id)
-		XCTAssertEqual(child.links[0].traceId, parent.traceId)
+		#expect(child.links.count == 1)
+		#expect(child.links[0].relationship == .parent)
+		#expect(child.links[0].id == parent.id)
+		#expect(child.links[0].traceId == parent.traceId)
 
-		XCTAssertEqual(parent.links.count, 1)
-		XCTAssertEqual(parent.links[0].relationship, .child)
-		XCTAssertEqual(parent.links[0].id, child.id)
-		XCTAssertEqual(parent.links[0].traceId, child.traceId)
+		#expect(parent.links.count == 1)
+		#expect(parent.links[0].relationship == .child)
+		#expect(parent.links[0].id == child.id)
+		#expect(parent.links[0].traceId == child.traceId)
 	}
 
-	func testFlushTrace() {
+	@Test
+	func flushTrace() {
 		let originalRoot = tracer.root
 		let originalTraceId = tracer.traceId
 
-		XCTAssertFalse(originalRoot.ended)
+		#expect(!originalRoot.ended)
 
 		let childSpan = tracer.startSpan(name: "test-child")
 		childSpan.end()
 
 		tracer.flushTrace()
 
-		XCTAssertTrue(originalRoot.ended)
+		#expect(originalRoot.ended)
 
 		let newRoot = tracer.root
-		XCTAssertNotIdentical(originalRoot, newRoot)
+		#expect(originalRoot !== newRoot)
 
 		let newTraceId = tracer.traceId
-		XCTAssertNotEqual(originalTraceId, newTraceId)
-		XCTAssertEqual(newRoot.traceId, newTraceId)
+		#expect(originalTraceId != newTraceId)
+		#expect(newRoot.traceId == newTraceId)
 
-		XCTAssertFalse(newRoot.ended)
-
-		XCTAssertEqual(tracer.retiredSpans.count, 0)
+		#expect(!newRoot.ended)
+		#expect(tracer.retiredSpans.count == 0)
 	}
 
-	func testIdleTimeout() {
+	@Test
+	func idleTimeout() async {
 		InstrumentationSystem.resetBootstrapForTests()
 
-		let expectation = expectation(description: "Idle received")
-		let reporter = TestReporter(self, idleExpectation: expectation)
-		InstrumentationSystem.bootstrap(reporter: reporter)
+		class IdleTestReporter: NautilusTelemetryReporter {
+			var idleTimeoutInterval: TimeInterval { 0.1 }
+			let onIdleTimeout: () -> Void
+			private let didFire = Mutex(false)
 
-		let span = InstrumentationSystem.tracer.startSpan(name: "retire test")
-		span.end()
+			init(onIdleTimeout: @escaping () -> Void) {
+				self.onIdleTimeout = onIdleTimeout
+			}
 
-		waitForExpectations(timeout: 10)
+			func reportSpans(_: [Span]) { }
+			func reportInstruments(_: [any Instrument]) { }
+			func subscribeToLifecycleEvents() { }
+			func idleTimeout() {
+				let alreadyFired = didFire.withLock { fired in
+					let was = fired
+					fired = true
+					return was
+				}
+				guard !alreadyFired else { return }
+				InstrumentationSystem.tracer.flushTimer?.suspend()
+				InstrumentationSystem.tracer.idleTimer?.suspend()
+				onIdleTimeout()
+			}
+		}
+
+		await confirmation("Idle received") { confirm in
+			let reporter = IdleTestReporter { confirm() }
+			InstrumentationSystem.bootstrap(reporter: reporter)
+
+			let span = InstrumentationSystem.tracer.startSpan(name: "retire test")
+			span.end()
+
+			try? await Task.sleep(for: .seconds(10))
+		}
+
 		InstrumentationSystem.resetBootstrapForTests()
 	}
 
-	func testTracerRootSpanIsRoot() {
+	@Test
+	func tracerRootSpanIsRoot() {
 		let tracer = Tracer()
 		let root = tracer.root
 
-		XCTAssertTrue(root.isRoot)
-		XCTAssertEqual(root.name, "root")
-		XCTAssertEqual(root.kind, .internal)
-		XCTAssertNil(root.parentId)
+		#expect(root.isRoot)
+		#expect(root.name == "root")
+		#expect(root.kind == .internal)
+		#expect(root.parentId == nil)
 	}
 
-	func testTracerRootSpanIsRootAfterFlush() {
+	@Test
+	func tracerRootSpanIsRootAfterFlush() {
 		let tracer = Tracer()
 		let originalRoot = tracer.root
 
-		XCTAssertTrue(originalRoot.isRoot)
+		#expect(originalRoot.isRoot)
 
 		tracer.flushTrace()
 
 		let newRoot = tracer.root
-		XCTAssertTrue(newRoot.isRoot)
-		XCTAssertNotIdentical(originalRoot, newRoot)
+		#expect(newRoot.isRoot)
+		#expect(originalRoot !== newRoot)
 	}
 
-	func testTracerChildSpanIsNotRoot() {
+	@Test
+	func tracerChildSpanIsNotRoot() {
 		let tracer = Tracer()
 		let childSpan = tracer.startSpan(name: "child")
 
-		XCTAssertFalse(childSpan.isRoot)
-		XCTAssertEqual(childSpan.parentId, tracer.root.id)
+		#expect(!childSpan.isRoot)
+		#expect(childSpan.parentId == tracer.root.id)
 	}
 
 	// MARK: - Baggage Attribute Propagation Tests
 
-	func testBaggageAttributesPropagateToSpan() {
+	@Test
+	func baggageAttributesPropagateToSpan() {
 		let parent = tracer.startSpan(name: "parent")
 		let baggage = Baggage(span: parent)
 		baggage["baggage.key"] = "baggage.value"
 
 		let child = tracer.buildSpan(name: "child", baggage: baggage)
-
-		XCTAssertEqual(child["baggage.key"], "baggage.value")
+		#expect(child["baggage.key"] as? String == "baggage.value")
 	}
 
-	func testSpanAttributesOverrideBaggageAttributes() {
+	@Test
+	func spanAttributesOverrideBaggageAttributes() {
 		let parent = tracer.startSpan(name: "parent")
 		let baggage = Baggage(span: parent)
 		baggage["shared.key"] = "from.baggage"
 
 		let spanAttributes: TelemetryAttributes = ["shared.key": "from.span"]
 		let child = tracer.buildSpan(name: "child", attributes: spanAttributes, baggage: baggage)
-
-		XCTAssertEqual(child["shared.key"], "from.span")
+		#expect(child["shared.key"] as? String == "from.span")
 	}
 
-	func testMergeAttributesBothNil() {
-		let result = tracer.mergeAttributes(baggageAttributes: nil, spanAttributes: nil)
-		XCTAssertNil(result)
+	@Test
+	func mergeAttributesBothNil() {
+		#expect(tracer.mergeAttributes(baggageAttributes: nil, spanAttributes: nil) == nil)
 	}
 
-	func testMergeAttributesBaggageOnlyNil() {
+	@Test
+	func mergeAttributesBaggageOnlyNil() {
 		let spanAttributes: TelemetryAttributes = ["span.key": "span.value"]
 		let result = tracer.mergeAttributes(baggageAttributes: nil, spanAttributes: spanAttributes)
-
-		XCTAssertEqual(result?["span.key"], "span.value")
+		#expect(result?["span.key"] as? String == "span.value")
 	}
 
-	func testMergeAttributesSpanOnlyNil() {
+	@Test
+	func mergeAttributesSpanOnlyNil() {
 		let baggageAttributes: TelemetryAttributes = ["baggage.key": "baggage.value"]
 		let result = tracer.mergeAttributes(baggageAttributes: baggageAttributes, spanAttributes: nil)
-
-		XCTAssertEqual(result?["baggage.key"], "baggage.value")
+		#expect(result?["baggage.key"] as? String == "baggage.value")
 	}
 
 	// MARK: - Error Propagation Tests
 
-	func testPropagateSpanRecordsErrorOnSpan() {
+	@Test
+	func propagateSpanRecordsErrorOnSpan() {
 		let span = tracer.startSpan(name: "test-span")
-
 		struct TestError: Error { }
 
-		do {
-			try tracer.propagateParent(span) {
-				throw TestError()
-			}
-			XCTFail("Expected error to be thrown")
-		} catch {
-			// Expected
-		}
+		try? tracer.propagateParent(span) { throw TestError() }
 
-		XCTAssertEqual(span.status, .error(message: "TestError()"))
-		XCTAssertEqual(span.events?.count, 1)
-		XCTAssertEqual(span.events?.first?.name, "exception")
+		#expect(span.status == .error(message: "TestError()"))
+		#expect(span.events?.count == 1)
+		#expect(span.events?.first?.name == "exception")
 	}
 
-	func testPropagateBaggageRecordsErrorOnSpan() {
+	@Test
+	func propagateBaggageRecordsErrorOnSpan() {
 		let span = tracer.startSpan(name: "test-span")
 		let baggage = Baggage(span: span)
-
 		struct TestError: Error { }
 
-		do {
-			try tracer.propagateBaggage(baggage) {
-				throw TestError()
-			}
-			XCTFail("Expected error to be thrown")
-		} catch {
-			// Expected
-		}
+		try? tracer.propagateBaggage(baggage) { throw TestError() }
 
-		XCTAssertEqual(span.status, .error(message: "TestError()"))
-		XCTAssertEqual(span.events?.count, 1)
-		XCTAssertEqual(span.events?.first?.name, "exception")
+		#expect(span.status == .error(message: "TestError()"))
+		#expect(span.events?.count == 1)
+		#expect(span.events?.first?.name == "exception")
+	}
+
+	@Test
+	func sampleRatePropagatedToChildSpan() {
+		let parent = tracer.startSpan(name: "parent")
+		parent.sampleRate = 25.0
+		let child = tracer.buildSpan(name: "child", baggage: Baggage(span: parent))
+		#expect(child.sampleRate == 25.0)
+	}
+
+	@Test
+	func sampleRatePropagatedToSubtraceSpan() {
+		let parent = tracer.startSpan(name: "parent")
+		parent.sampleRate = 75.0
+		let baggage = Baggage(span: parent, subTraceId: Identifiers.generateTraceId())
+		let child = tracer.buildSpan(name: "child", baggage: baggage)
+		#expect(child.sampleRate == 75.0)
 	}
 
 }

--- a/Tests/NautilusTelemetryTests/Utilities/SamplerTests.swift
+++ b/Tests/NautilusTelemetryTests/Utilities/SamplerTests.swift
@@ -28,6 +28,20 @@ final class SamplerTests: XCTestCase {
 		XCTAssert(sampler2.shouldSample) // should be true with the new GUID
 	}
 
+	// ≈1µs/sample decision in debug, ≈.5µs in release.
+	func testStableGuidSamplerPerformance() {
+		let seed = Data([0x00])
+		let guid = Data([0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+		                 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10])
+
+		measure {
+			for _ in 0..<1_000_000 {
+				let sampler = StableGuidSampler(sampleRate: 50.0, seed: seed, guid: guid)
+				_ = sampler.shouldSample
+			}
+		}
+	}
+
 	func testStableGuidSamplerSampleRates() throws {
 		guard TestUtils.testEnabled("testStableGuidSamplerSampleRates") else {
 			throw XCTSkip("This is a local-only test, not needed on CI")


### PR DESCRIPTION
- Add sample rate override for specific spans & their children.
- Add sample implementation to ExampleReporter.
- Convert `SpanTests` and `TracerTests` to Swift Testing + tests for new behavior.

@jparise 
@bachand
