### PR TITLE
Implement span attribute collection

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set Xcode version
-      run: sudo xcode-select -s /Applications/Xcode_26.4.0.app
+      run: sudo xcode-select -s /Applications/Xcode_26.4.1.app
     - name: Build and run tests for the matrix
       run: xcodebuild ${{ matrix.xcodebuild-command }} -scheme NautilusTelemetry-Package -destination "${{ matrix.xcodebuild-destination }}"
 

--- a/Sources/NautilusTelemetry/Tracing/Tracer+Metrics.swift
+++ b/Sources/NautilusTelemetry/Tracing/Tracer+Metrics.swift
@@ -21,12 +21,14 @@ extension Tracer {
 	///   - span: the span to count. A metric name will be derived from the span name.
 	///   - namingConvention: determines how to derive the metric name
 	///   - fileID: fileID where the span was created, for module name determination.
+	///   - spanAttributeKeys: A set of attribute keys to collect from the span when it is ended. This set should be minimal to avoid metric cardinality explosion.
 	/// - Returns: the created counter.
 	@discardableResult
 	public func reportAsCounterMetric(
 		span: Span,
 		namingConvention: MetricNamingConvention = .modulePrefix,
-		fileID: String = #fileID
+		fileID: String = #fileID,
+		spanAttributeKeys: Set<String>? = nil
 	) -> Counter<Int> {
 		let name = metricName(span: span, namingConvention: namingConvention, fileID: fileID, suffix: "_counter")
 
@@ -41,9 +43,9 @@ extension Tracer {
 			return counter
 		}
 
-		span.addRetireCallback { [weak counter] _ in
+		span.addRetireCallback { [weak counter] span in
 			guard let counter else { return }
-			counter.add(1)
+			counter.add(1, attributes: Self.collectAttributes(span, spanAttributeKeys))
 		}
 
 		return counter
@@ -53,15 +55,17 @@ extension Tracer {
 	/// The histogram is strongly referenced through Meter's register, and a cached copy will be returned if the derived metric name matches.
 	/// Callers need only hold a reference to the histogram if they need to later unregister.
 	/// - Parameters:
-	///   - span: the span to count. A metric name will be derived from the span name.
+	///   - span: the span to measure. A metric name will be derived from the span name.
 	///   - namingConvention: determines how to derive the metric name
 	///   - fileID: fileID where the span was created, for module name determination.
+	///   - spanAttributeKeys: A set of attribute keys to collect from the span when it is ended. This set should be minimal to avoid metric cardinality explosion.
 	/// - Returns: the created histogram.
 	@discardableResult
 	public func reportAsDurationHistogramMetric(
 		span: Span,
 		namingConvention: MetricNamingConvention = .modulePrefix,
-		fileID: String = #fileID
+		fileID: String = #fileID,
+		spanAttributeKeys: Set<String>? = nil
 	) -> ExponentialHistogram<Int> {
 		let name = metricName(span: span, namingConvention: namingConvention, fileID: fileID, suffix: "_histogram")
 
@@ -78,13 +82,23 @@ extension Tracer {
 
 		span.addRetireCallback { [weak histogram] span in
 			guard let histogram, let elapsed = span.elapsed else { return }
-			histogram.record(Int(elapsed.asMilliseconds))
+			histogram.record(Int(elapsed.asMilliseconds), attributes: Self.collectAttributes(span, spanAttributeKeys))
 		}
 
 		return histogram
 	}
 
 	// MARK: Internal
+
+	/// Collect a set of named span attributes
+	/// - Parameters:
+	///   - span: The span
+	///   - spanAttributeKeys: The names of attributes to collect
+	/// - Returns: The matching attributes, or an empty dictionary if no keys were requested or none matched.
+	static func collectAttributes(_ span: Span, _ spanAttributeKeys: Set<String>?) -> TelemetryAttributes {
+		guard let spanAttributeKeys, !spanAttributeKeys.isEmpty else { return [:] }
+		return span.attributes?.filter { spanAttributeKeys.contains($0.key) } ?? [:]
+	}
 
 	func metricName(span: Span, namingConvention: MetricNamingConvention, fileID: String = #fileID, suffix: String) -> String {
 		switch namingConvention {

--- a/Tests/NautilusTelemetryTests/Tracing/Tracer+MetricsTests.swift
+++ b/Tests/NautilusTelemetryTests/Tracing/Tracer+MetricsTests.swift
@@ -1,0 +1,154 @@
+// Created by Ladd Van Tol on 2026-04-30.
+// Copyright © 2026 Airbnb Inc. All rights reserved.
+
+import Foundation
+import Testing
+
+@testable import NautilusTelemetry
+
+@Suite
+struct TracerMetricsTests {
+
+	let tracer = Tracer()
+
+	@Test
+	func reportAsCounterMetricCopiesSelectedSpanAttributes() {
+		let span = tracer.startSpan(name: "counterAttrSpan")
+		span.addAttribute("included.string", "hello")
+		span.addAttribute("excluded", "should_not_appear")
+
+		let counter = tracer.reportAsCounterMetric(
+			span: span,
+			spanAttributeKeys: Set(["included.string", "included.int"])
+		)
+
+		// Attributes are collected at retire time, so this addition should be visible.
+		span.addAttribute("included.int", 7)
+
+		span.end()
+
+		let expected: TelemetryAttributes = [
+			"included.string": "hello",
+			"included.int": 7,
+		]
+		#expect(counter.values.valueFor(attributes: expected) == 1)
+	}
+
+	@Test
+	func reportAsDurationHistogramMetricCopiesSelectedSpanAttributes() {
+		let span = tracer.startSpan(name: "histogramAttrSpan")
+		span.addAttribute("route", "/users/:id")
+		span.addAttribute("excluded", "nope")
+
+		let histogram = tracer.reportAsDurationHistogramMetric(
+			span: span,
+			spanAttributeKeys: Set(["route", "method"])
+		)
+
+		// Attributes are collected at retire time, so this addition should be visible.
+		span.addAttribute("method", "GET")
+		span.adjust(start: .zero, end: .milliseconds(42))
+		span.end()
+
+		let expected: TelemetryAttributes = [
+			"route": "/users/:id",
+			"method": "GET",
+		]
+		let buckets = histogram.values.values[expected]
+		#expect(buckets?.count == 1)
+		#expect(buckets?.sum == 42)
+	}
+
+	@Test
+	func reportAsCounterMetricWithNilKeysUsesEmptyAttributes() {
+		let span = tracer.startSpan(name: "counterNilKeysSpan")
+		span.addAttribute("any", "value")
+
+		let counter = tracer.reportAsCounterMetric(span: span, spanAttributeKeys: nil)
+
+		span.end()
+
+		#expect(counter.values.valueFor(attributes: [:]) == 1)
+	}
+
+	@Test
+	func reportAsCounterMetricWithNonMatchingKeysUsesEmptyAttributes() {
+		let span = tracer.startSpan(name: "counterNoMatchSpan")
+		span.addAttribute("present", "yes")
+
+		let counter = tracer.reportAsCounterMetric(
+			span: span,
+			spanAttributeKeys: Set(["absent"])
+		)
+
+		span.end()
+
+		#expect(counter.values.valueFor(attributes: [:]) == 1)
+	}
+
+	@Test
+	func reportAsCounterMetricWithNoSpanAttributes() {
+		// Exercises the `span.attributes == nil` branch in collectAttributes.
+		let span = tracer.startSpan(name: "counterNoAttrSpan")
+
+		let counter = tracer.reportAsCounterMetric(
+			span: span,
+			spanAttributeKeys: Set(["anything"])
+		)
+
+		span.end()
+
+		#expect(counter.values.valueFor(attributes: [:]) == 1)
+	}
+
+	@Test
+	func sharedCounterCapturesPerSpanAttributeKeys() {
+		// Two spans with the same name share a cached counter, but each retire callback
+		// should use its own captured spanAttributeKeys.
+		let span1 = tracer.startSpan(name: "sharedCounterSpan")
+		span1.addAttribute("a", "1")
+		span1.addAttribute("b", "1")
+
+		let span2 = tracer.startSpan(name: "sharedCounterSpan")
+		span2.addAttribute("a", "2")
+		span2.addAttribute("b", "2")
+
+		let counter1 = tracer.reportAsCounterMetric(span: span1, spanAttributeKeys: Set(["a"]))
+		let counter2 = tracer.reportAsCounterMetric(span: span2, spanAttributeKeys: Set(["b"]))
+		#expect(counter1 === counter2)
+
+		span1.end()
+		span2.end()
+
+		#expect(counter1.values.valueFor(attributes: ["a": "1"]) == 1)
+		#expect(counter1.values.valueFor(attributes: ["b": "2"]) == 1)
+	}
+
+	@Test
+	func collectAttributesFiltersToRequestedKeys() {
+		let span = tracer.startSpan(name: "collectSpan")
+		span.addAttribute("a", 1)
+		span.addAttribute("b", 2)
+		span.addAttribute("c", 3)
+
+		let filtered = Tracer.collectAttributes(span, Set(["a", "c"]))
+		#expect(filtered == ["a": AnyHashable(1), "c": AnyHashable(3)])
+	}
+
+	@Test
+	func collectAttributesReturnsEmptyForEmptyOrNilKeys() {
+		let span = tracer.startSpan(name: "collectSpan")
+		span.addAttribute("a", 1)
+
+		#expect(Tracer.collectAttributes(span, nil).isEmpty)
+		#expect(Tracer.collectAttributes(span, Set<String>()).isEmpty)
+	}
+
+	@Test
+	func collectAttributesReturnsEmptyWhenNoKeysMatch() {
+		let span = tracer.startSpan(name: "collectSpan")
+		span.addAttribute("a", 1)
+
+		#expect(Tracer.collectAttributes(span, Set(["missing"])).isEmpty)
+	}
+}


### PR DESCRIPTION
Allow copying selected span attributes into a derived metric. Concretely, this enables segmenting app launch measurement by type (prewarm, new install, upgrade, etc), and is otherwise useful for span-derived metrics.

@jparise 
@bachand

