### PR TITLE
Eliminate AnyHashable

### DIFF
--- a/Sources/NautilusTelemetry/Exporters/Exporter.swift
+++ b/Sources/NautilusTelemetry/Exporters/Exporter.swift
@@ -60,66 +60,40 @@ public struct Exporter {
 		return String(timeReference.nanosecondsSinceEpoch(from: time))
 	}
 
-	/// Converts common value types to OTLP format.
-	/// - Parameter value: Any value type.
-	/// - Returns: OTLP wrapped type, or nil if it could not be converted.
-	func convertToOTLP(value: Any) -> OTLP.V1AnyValue? {
-		var v1AnyValue: OTLP.V1AnyValue? = nil
-
+	/// Converts an `AttributeValue` to OTLP format.
+	/// - Parameter value: an `AttributeValue`.
+	/// - Returns: OTLP wrapped type.
+	func convertToOTLP(value: AttributeValue) -> OTLP.V1AnyValue {
 		switch value {
-		case let value as String:
-			v1AnyValue = OTLP.V1AnyValue(stringValue: value)
-
-		case let value as any FixedWidthInteger:
-			v1AnyValue = OTLP.V1AnyValue(intValue: value)
-
-		case let value as Bool:
-			v1AnyValue = OTLP.V1AnyValue(boolValue: value)
-
-		case let value as Float:
-			v1AnyValue = OTLP.V1AnyValue(doubleValue: Double(value))
-
-		case let value as Double:
-			v1AnyValue = OTLP.V1AnyValue(doubleValue: value)
-
-		case let value as Data:
-			v1AnyValue = OTLP.V1AnyValue(bytesValue: value)
-
-		case let value as [Any]:
-			let otlpArray = value.compactMap { convertToOTLP(value: $0) }
-			v1AnyValue = OTLP.V1AnyValue(arrayValue: OTLP.V1ArrayValue(values: otlpArray))
-
-		case let value as [String: Any]:
-			let otlpValues = value.compactMap { key, value in OTLP.V1KeyValue(key: key, value: convertToOTLP(value: value)) }
-			v1AnyValue = OTLP.V1AnyValue(kvlistValue: OTLP.V1KeyValueList(values: otlpValues))
-
-		default:
-			v1AnyValue = nil
+		case .string(let v):
+			OTLP.V1AnyValue(stringValue: v)
+		case .int(let v):
+			OTLP.V1AnyValue(intValue: v)
+		case .double(let v):
+			OTLP.V1AnyValue(doubleValue: v)
+		case .bool(let v):
+			OTLP.V1AnyValue(boolValue: v)
+		case .data(let v):
+			OTLP.V1AnyValue(bytesValue: v)
+		case .array(let v):
+			OTLP.V1AnyValue(arrayValue: OTLP.V1ArrayValue(values: v.map { convertToOTLP(value: $0) }))
+		case .keyValueList(let v):
+			OTLP.V1AnyValue(kvlistValue: OTLP.V1KeyValueList(
+				values: v.map { OTLP.V1KeyValue(key: $0.key, value: convertToOTLP(value: $0.value)) }
+			))
 		}
-
-		return v1AnyValue
 	}
 
 	/// Converts `TelemetryAttributes` to OTLP format.
 	/// - Parameter attributes: TelemetryAttributes.
-	/// - Returns: attributes converted to OTLP format. Values that cannot be converted are omitted.
+	/// - Returns: attributes converted to OTLP format.
 	func convertToOTLP(attributes: TelemetryAttributes?) -> [OTLP.V1KeyValue]? {
 		guard let attributes else {
 			return nil
 		}
 
-		let otlpAttributes = attributes.compactMap { key, value -> OTLP.V1KeyValue? in
-			// Skip nil values wrapped in AnyHashable
-			if case Optional<Any>.none = value.base {
-				return nil
-			}
-
-			guard let v1AnyValue = convertToOTLP(value: value) else {
-				assert(false, "failed to convert \(key), \(value)")
-				return nil
-			}
-
-			return OTLP.V1KeyValue(key: key, value: v1AnyValue)
+		let otlpAttributes = attributes.map { key, value in
+			OTLP.V1KeyValue(key: key, value: convertToOTLP(value: value))
 		}
 
 		// Sort by key for deterministic output

--- a/Sources/NautilusTelemetry/Exporters/OTLP-JSON/Common/V1AnyValue.swift
+++ b/Sources/NautilusTelemetry/Exporters/OTLP-JSON/Common/V1AnyValue.swift
@@ -16,13 +16,13 @@ extension OTLP {
 
 		var stringValue: String?
 		var boolValue: Bool?
-		var intValue: (any FixedWidthInteger)?
+		var intValue: Int64?
 		var doubleValue: Double?
 		var arrayValue: V1ArrayValue?
 		var kvlistValue: V1KeyValueList?
 		var bytesValue: Data?
 
-		init(stringValue: String? = nil, boolValue: Bool? = nil, intValue: (any FixedWidthInteger)? = nil, doubleValue: Double? = nil, arrayValue: V1ArrayValue? = nil, kvlistValue: V1KeyValueList? = nil, bytesValue: Data? = nil) {
+		init(stringValue: String? = nil, boolValue: Bool? = nil, intValue: Int64? = nil, doubleValue: Double? = nil, arrayValue: V1ArrayValue? = nil, kvlistValue: V1KeyValueList? = nil, bytesValue: Data? = nil) {
 			self.stringValue = stringValue
 			self.boolValue = boolValue
 			self.intValue = intValue
@@ -42,25 +42,23 @@ extension OTLP {
 			case bytesValue
 		}
 
-		// Encodable protocol methods
-		static let preciseIntegerRangeInJSONNumbers = -(1 << 53)...(1 << 53)
+		/// IEEE 754 `Double` can represent every integer in `[-2^53, 2^53]` exactly.
+		/// Values in this range encode as JSON numbers; outside, ProtoJSON spec requires
+		/// a JSON string. https://protobuf.dev/programming-guides/json/
+		static let preciseIntegerRangeInJSONNumbers: ClosedRange<Int64> = -(1 << 53)...(1 << 53)
 
 		func encode(to encoder: Encoder) throws {
 			var container = encoder.container(keyedBy: CodingKeys.self)
 			try container.encodeIfPresent(stringValue, forKey: .stringValue)
 			try container.encodeIfPresent(boolValue, forKey: .boolValue)
-			// ProtoJSON allows either JSON string or JSON number for integer values
-			// We know that IEEE Double Floats can accurately represent integers
-			// in the range (-2^53,2^53), so optimize this encoding
-			// https://protobuf.dev/programming-guides/json/
 
-			// Int is 64 bit in all environments we care about
-			if let intValue = intValue as? Int, Self.preciseIntegerRangeInJSONNumbers.contains(intValue) {
-				try container.encodeIfPresent(intValue, forKey: .intValue)
-			} else if let intValue = intValue {
-				// Int128 and other weird types handled by the string fallback
-				let intAsString = "\(intValue)"
-				try container.encodeIfPresent(intAsString, forKey: .intValue)
+			if let intValue {
+				if Self.preciseIntegerRangeInJSONNumbers.contains(intValue) {
+					try container.encode(intValue, forKey: .intValue)
+				} else {
+					// Outside the precise range: emit as a JSON string to preserve the value.
+					try container.encode("\(intValue)", forKey: .intValue)
+				}
 			}
 
 			try container.encodeIfPresent(doubleValue, forKey: .doubleValue)

--- a/Sources/NautilusTelemetry/Instrumentation/NetworkMonitor.swift
+++ b/Sources/NautilusTelemetry/Instrumentation/NetworkMonitor.swift
@@ -20,13 +20,13 @@ public final class NetworkMonitor {
 		var attributes = TelemetryAttributes()
 
 		if let networkPath = networkPath.withLock({ $0 }) {
-			attributes["network.path.status"] = networkPath.status.description
+			attributes["network.path.status"] = .string(networkPath.status.description)
 			if networkPath.status == .unsatisfied {
-				attributes["network.path.unsatisfied_reason"] = networkPath.unsatisfiedReason.description
+				attributes["network.path.unsatisfied_reason"] = .string(networkPath.unsatisfiedReason.description)
 			}
 
 			if #available(iOS 26.0, macOS 26.0, *) {
-				attributes["network.path.link_quality"] = networkPath.linkQuality.description
+				attributes["network.path.link_quality"] = .string(networkPath.linkQuality.description)
 			}
 		}
 
@@ -36,7 +36,7 @@ public final class NetworkMonitor {
 			let serviceCurrentRadioAccessTechnology = telephonyNetworkInfo.serviceCurrentRadioAccessTechnology,
 			let radioAccessTechnology = serviceCurrentRadioAccessTechnology[dataServiceIdentifier]
 		{
-			attributes["network.connection.subtype"] = radioAccessTechnologyDescription(radioAccessTechnology)
+			attributes["network.connection.subtype"] = .string(radioAccessTechnologyDescription(radioAccessTechnology))
 		}
 		#endif
 

--- a/Sources/NautilusTelemetry/Instrumentation/ResourceAttributes.swift
+++ b/Sources/NautilusTelemetry/Instrumentation/ResourceAttributes.swift
@@ -141,20 +141,20 @@ public struct ResourceAttributes {
 
 		// https://opentelemetry.io/docs/specs/semconv/registry/attributes/service/
 		if options.contains(.serviceName) {
-			attributes["service.name"] = "\(osName.lowercased()).app"
+			attributes["service.name"] = .string("\(osName.lowercased()).app")
 		}
 		if options.contains(.serviceNamespace) {
-			attributes["service.namespace"] = bundleIdentifier
+			attributes["service.namespace"] = .string(bundleIdentifier)
 		}
 		if options.contains(.serviceVersion) {
-			attributes["service.version"] = applicationVersion
+			attributes["service.version"] = .string(applicationVersion)
 		}
 		if options.contains(.telemetrySdk) {
 			attributes["telemetry.sdk.name"] = "NautilusTelemetry"
 			attributes["telemetry.sdk.language"] = "swift"
 		}
 		if options.contains(.deviceId) {
-			attributes["device.id"] = vendorIdentifier
+			attributes["device.id"] = .string(vendorIdentifier)
 		}
 		// Can we set "deployment.environment" here?
 
@@ -163,18 +163,18 @@ public struct ResourceAttributes {
 			attributes["device.manufacturer"] = "Apple"
 		}
 		if options.contains(.deviceModel) {
-			attributes["device.model"] = deviceModelIdentifier
+			attributes["device.model"] = .string(deviceModelIdentifier)
 		}
 
 		// https://opentelemetry.io/docs/specs/semconv/resource/os/
 		if options.contains(.osType) {
-			attributes["os.type"] = osType
+			attributes["os.type"] = .string(osType)
 		}
 		if options.contains(.osName) {
-			attributes["os.name"] = osName
+			attributes["os.name"] = .string(osName)
 		}
 		if options.contains(.osVersion) {
-			attributes["os.version"] = osVersion
+			attributes["os.version"] = .string(osVersion)
 		}
 
 		if let additionalAttributes {

--- a/Sources/NautilusTelemetry/Metrics/Counter.swift
+++ b/Sources/NautilusTelemetry/Metrics/Counter.swift
@@ -37,7 +37,7 @@ public class Counter<T: MetricNumeric>: Instrument, ExportableInstrument {
 			assert(false, "monotonic counters can only be increased")
 			return
 		}
-		lock.withLockUnchecked {
+		lock.withLock {
 			values.add(number, attributes: attributes)
 		}
 	}

--- a/Sources/NautilusTelemetry/Metrics/ExponentialHistogram.swift
+++ b/Sources/NautilusTelemetry/Metrics/ExponentialHistogram.swift
@@ -50,7 +50,7 @@ public class ExponentialHistogram<T: MetricNumeric>: Instrument, ExportableInstr
 	/// Record a value. Positive, negative, and zero values are all allowed (unlike `Histogram`),
 	/// since the spec maps them into separate positive/negative/zero buckets.
 	public func record(_ number: T, attributes: TelemetryAttributes = [:]) {
-		lock.withLockUnchecked {
+		lock.withLock {
 			values.record(number, attributes: attributes)
 		}
 	}
@@ -59,7 +59,7 @@ public class ExponentialHistogram<T: MetricNumeric>: Instrument, ExportableInstr
 		let now = ContinuousClock.now
 
 		return lock.withLock {
-			let copy = Self(name: name, unit: unit, description: description)
+			let copy = Self(name: name, unit: unit, description: description, maxBuckets: maxBuckets)
 			copy.startTime = startTime
 			copy.endTime = now
 			copy.aggregationTemporality = aggregationTemporality

--- a/Sources/NautilusTelemetry/Metrics/Histogram.swift
+++ b/Sources/NautilusTelemetry/Metrics/Histogram.swift
@@ -42,7 +42,7 @@ public class Histogram<T: MetricNumeric>: Instrument, ExportableInstrument {
 			return
 		}
 
-		lock.withLockUnchecked {
+		lock.withLock {
 			values.record(number, attributes: attributes)
 		}
 	}

--- a/Sources/NautilusTelemetry/Metrics/ObservableCounter.swift
+++ b/Sources/NautilusTelemetry/Metrics/ObservableCounter.swift
@@ -34,7 +34,7 @@ public class ObservableCounter<T: MetricNumeric>: Instrument, ExportableInstrume
 
 	/// https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/api.md#asynchronous-counter-creation
 	public func observe(_ number: T, attributes: TelemetryAttributes = [:]) {
-		lock.withLockUnchecked {
+		lock.withLock {
 			values.set(number, attributes: attributes)
 		}
 	}

--- a/Sources/NautilusTelemetry/Metrics/ObservableGauge.swift
+++ b/Sources/NautilusTelemetry/Metrics/ObservableGauge.swift
@@ -31,7 +31,7 @@ public class ObservableGauge<T: MetricNumeric>: Instrument, ExportableInstrument
 	public var isEmpty: Bool { false }
 
 	public func observe(_ number: T, attributes: TelemetryAttributes = [:]) {
-		lock.withLockUnchecked {
+		lock.withLock {
 			values.set(number, attributes: attributes)
 		}
 	}

--- a/Sources/NautilusTelemetry/Metrics/ObservableUpDownCounter.swift
+++ b/Sources/NautilusTelemetry/Metrics/ObservableUpDownCounter.swift
@@ -33,7 +33,7 @@ public class ObservableUpDownCounter<T: MetricNumeric>: Instrument, ExportableIn
 	public var isEmpty: Bool { lock.withLock { values.isEmpty } }
 
 	public func observe(_ number: T, attributes: TelemetryAttributes = [:]) {
-		lock.withLockUnchecked {
+		lock.withLock {
 			values.set(number, attributes: attributes)
 		}
 	}

--- a/Sources/NautilusTelemetry/Tracing/Baggage.swift
+++ b/Sources/NautilusTelemetry/Tracing/Baggage.swift
@@ -57,12 +57,10 @@ public final class Baggage: TelemetryAttributesContainer, @unchecked Sendable {
 	/// - Parameters:
 	///   - name: a name, conforming to https://github.com/open-telemetry/opentelemetry-specification/tree/main/specification/trace/semantic_conventions
 	///   - value: a value.
-	public func addAttribute(_ name: String, _ value: AnyHashable?) {
+	public func addAttribute(_ name: String, _ value: AttributeValue?) {
 		guard let value else { return }
 
-		// AnyHashable is not Sendable. For now, make this unchecked, but could consider wrapping ala:
-		// https://github.com/pointfreeco/swift-concurrency-extras/blob/main/Sources/ConcurrencyExtras/AnyHashableSendable.swift
-		lock.withLockUnchecked {
+		lock.withLock {
 			if _attributes == nil {
 				_attributes = TelemetryAttributes()
 			}
@@ -71,9 +69,9 @@ public final class Baggage: TelemetryAttributesContainer, @unchecked Sendable {
 		}
 	}
 
-	public subscript(name: String) -> AnyHashable? {
+	public subscript(name: String) -> AttributeValue? {
 		get {
-			lock.withLockUnchecked {
+			lock.withLock {
 				_attributes?[name]
 			}
 		}
@@ -93,7 +91,7 @@ public final class Baggage: TelemetryAttributesContainer, @unchecked Sendable {
 
 	/// Vend private attributes as a thread-safe copy
 	var attributes: TelemetryAttributes? {
-		lock.withLockUnchecked { _attributes }
+		lock.withLock { _attributes }
 	}
 
 	// MARK: Private

--- a/Sources/NautilusTelemetry/Tracing/Span.swift
+++ b/Sources/NautilusTelemetry/Tracing/Span.swift
@@ -144,12 +144,10 @@ public final class Span: TelemetryAttributesContainer, Identifiable {
 	/// - Parameters:
 	///   - name: a name, conforming to https://github.com/open-telemetry/opentelemetry-specification/tree/main/specification/trace/semantic_conventions
 	///   - value: a value.
-	public func addAttribute(_ name: String, _ value: AnyHashable?) {
+	public func addAttribute(_ name: String, _ value: AttributeValue?) {
 		guard let value else { return }
 
-		// AnyHashable is not Sendable. For now, make this unchecked, but could consider wrapping ala:
-		// https://github.com/pointfreeco/swift-concurrency-extras/blob/main/Sources/ConcurrencyExtras/AnyHashableSendable.swift
-		lock.withLockUnchecked {
+		lock.withLock {
 			if _attributes == nil {
 				_attributes = TelemetryAttributes()
 			}
@@ -158,9 +156,9 @@ public final class Span: TelemetryAttributesContainer, Identifiable {
 		}
 	}
 
-	public subscript(name: String) -> AnyHashable? {
+	public subscript(name: String) -> AttributeValue? {
 		get {
-			lock.withLockUnchecked {
+			lock.withLock {
 				_attributes?[name]
 			}
 		}
@@ -201,7 +199,7 @@ public final class Span: TelemetryAttributesContainer, Identifiable {
 		// https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/exceptions.md
 
 		let attributes = Self.exceptionAttributes(error, includeBacktrace: includeBacktrace)
-		let message = attributes["exception.message"] ?? ""
+		let message: String = if case .string(let m) = attributes["exception.message"] { m } else { "" }
 		let exceptionEvent = Event(name: "exception", attributes: attributes)
 		addEvent(exceptionEvent)
 		status = .error(message: message) // this duplicates exception.message, but makes the reporting work better
@@ -268,7 +266,7 @@ public final class Span: TelemetryAttributesContainer, Identifiable {
 
 	/// Vend private attributes as a thread-safe copy
 	var attributes: TelemetryAttributes? {
-		lock.withLockUnchecked { _attributes }
+		lock.withLock { _attributes }
 	}
 
 	var elapsed: Duration? {
@@ -276,7 +274,7 @@ public final class Span: TelemetryAttributesContainer, Identifiable {
 		return endTime - startTime
 	}
 
-	static func exceptionAttributes(_ error: any Error, includeBacktrace: Bool) -> [String: String] {
+	static func exceptionAttributes(_ error: any Error, includeBacktrace: Bool) -> TelemetryAttributes {
 		let exceptionType: String
 		let exceptionMessage: String
 
@@ -328,13 +326,13 @@ public final class Span: TelemetryAttributesContainer, Identifiable {
 
 	private var _attributes: TelemetryAttributes?
 
-	private static func exceptionAttributes(type: String, message: String, stacktrace: String?) -> [String: String] {
-		var attributes = [
-			"exception.type": type,
-			"exception.message": message,
+	private static func exceptionAttributes(type: String, message: String, stacktrace: String?) -> TelemetryAttributes {
+		var attributes: TelemetryAttributes = [
+			"exception.type": .string(type),
+			"exception.message": .string(message),
 		]
 		if let stacktrace {
-			attributes["exception.stacktrace"] = stacktrace
+			attributes["exception.stacktrace"] = .string(stacktrace)
 		}
 
 		return attributes

--- a/Sources/NautilusTelemetry/Utilities/AttributeValue+Migration.swift
+++ b/Sources/NautilusTelemetry/Utilities/AttributeValue+Migration.swift
@@ -1,0 +1,62 @@
+// Created by Ladd Van Tol on 2026-05-01.
+// Copyright © 2026 Airbnb Inc. All rights reserved.
+
+import Foundation
+
+// Transitional helpers to smooth migration from `[String: AnyHashable]` /
+// `[String: String]`-style call sites to `TelemetryAttributes` (keyed by
+// `AttributeValue`). Everything in this file is `@available(*, deprecated, ...)`
+// so callers get a compiler pointer to the replacement pattern.
+//
+// Subscript-style assignments (`attributes[key] = someStringVar`) cannot be
+// smoothed: Swift's stdlib `Dictionary` subscript isn't overridable by return
+// type via extension, so those call sites must convert manually
+// (e.g. `attributes[key] = .string(someStringVar)`).
+
+// MARK: - `[String: String]` conversion
+
+extension [String: String] {
+	/// Convert a string-valued dictionary to `TelemetryAttributes`.
+	@available(*, deprecated, message: "Construct a TelemetryAttributes directly with AttributeValue values.")
+	public var asTelemetryAttributes: TelemetryAttributes {
+		mapValues(AttributeValue.string)
+	}
+}
+
+// MARK: - Exporter overloads accepting `[String: String]`
+
+extension Exporter {
+	@available(
+		*,
+		deprecated,
+		message: "Pass TelemetryAttributes (Dictionary<String, AttributeValue>) instead of [String: String]."
+	)
+	public func exportOTLPToJSON(
+		spans: [Span],
+		additionalAttributes: [String: String],
+		resourceAttributeOptions: ResourceAttributeOptions = .all
+	) throws -> Data {
+		try exportOTLPToJSON(
+			spans: spans,
+			additionalAttributes: additionalAttributes.mapValues(AttributeValue.string),
+			resourceAttributeOptions: resourceAttributeOptions
+		)
+	}
+
+	@available(
+		*,
+		deprecated,
+		message: "Pass TelemetryAttributes (Dictionary<String, AttributeValue>) instead of [String: String]."
+	)
+	public func exportOTLPToJSON(
+		instruments: [Instrument],
+		additionalAttributes: [String: String],
+		resourceAttributeOptions: ResourceAttributeOptions = ResourceAttributeOptions.metricSubset
+	) throws -> Data {
+		try exportOTLPToJSON(
+			instruments: instruments,
+			additionalAttributes: additionalAttributes.mapValues(AttributeValue.string),
+			resourceAttributeOptions: resourceAttributeOptions
+		)
+	}
+}

--- a/Sources/NautilusTelemetry/Utilities/AttributeValue.swift
+++ b/Sources/NautilusTelemetry/Utilities/AttributeValue.swift
@@ -1,0 +1,240 @@
+// Created by Ladd Van Tol on 2026-05-01.
+// Copyright © 2026 Airbnb Inc. All rights reserved.
+
+import Foundation
+
+// MARK: - AttributeValue
+
+/// A closed set of value types permitted in `TelemetryAttributes`.
+///
+/// Models the types accepted by OTLP attribute values:
+/// https://opentelemetry.io/docs/specs/otel/common/#attribute
+///
+/// Using a closed enum instead of `AnyHashable` avoids existential dispatch on hashing
+/// (attributes form dictionary keys throughout the hot path) and makes `TelemetryAttributes`
+/// `Sendable`.
+public enum AttributeValue: Hashable, Sendable {
+	case string(String)
+	case int(Int64)
+	case double(Double)
+	case bool(Bool)
+	case data(Data)
+	indirect case array([AttributeValue])
+	indirect case keyValueList([String: AttributeValue])
+}
+
+// MARK: - Payload accessors
+
+/// Non-throwing accessors for the underlying payload. Return `nil` if the case does not match.
+extension AttributeValue {
+	public var stringValue: String? {
+		if case .string(let v) = self { v } else { nil }
+	}
+
+	public var intValue: Int64? {
+		if case .int(let v) = self { v } else { nil }
+	}
+
+	public var doubleValue: Double? {
+		if case .double(let v) = self { v } else { nil }
+	}
+
+	public var boolValue: Bool? {
+		if case .bool(let v) = self { v } else { nil }
+	}
+
+	public var dataValue: Data? {
+		if case .data(let v) = self { v } else { nil }
+	}
+}
+
+// MARK: ExpressibleByStringLiteral, ExpressibleByStringInterpolation
+
+/// Enables `span["k"] = "value"`, `span["k"] = 42`, etc. without explicit case construction.
+extension AttributeValue: ExpressibleByStringLiteral, ExpressibleByStringInterpolation {
+	public init(stringLiteral value: String) { self = .string(value) }
+}
+
+// MARK: ExpressibleByIntegerLiteral
+
+extension AttributeValue: ExpressibleByIntegerLiteral {
+	public init(integerLiteral value: Int64) { self = .int(value) }
+}
+
+// MARK: ExpressibleByFloatLiteral
+
+extension AttributeValue: ExpressibleByFloatLiteral {
+	public init(floatLiteral value: Double) { self = .double(value) }
+}
+
+// MARK: ExpressibleByBooleanLiteral
+
+extension AttributeValue: ExpressibleByBooleanLiteral {
+	public init(booleanLiteral value: Bool) { self = .bool(value) }
+}
+
+// MARK: ExpressibleByArrayLiteral
+
+extension AttributeValue: ExpressibleByArrayLiteral {
+	public init(arrayLiteral elements: AttributeValue...) { self = .array(elements) }
+}
+
+// MARK: ExpressibleByDictionaryLiteral
+
+extension AttributeValue: ExpressibleByDictionaryLiteral {
+	public init(dictionaryLiteral elements: (String, AttributeValue)...) {
+		self = .keyValueList(Dictionary(uniqueKeysWithValues: elements))
+	}
+}
+
+// MARK: - Convenience initializers
+
+/// Convenience initializers for non-literal values (e.g. variables of `String`, `Int`, `Bool`, `Data`).
+/// The literal conformances above handle the common inline-literal case.
+extension AttributeValue {
+	public init(_ value: String) { self = .string(value) }
+	public init(_ value: some FixedWidthInteger) { self = .int(Int64(truncatingIfNeeded: value)) }
+	public init(_ value: Double) { self = .double(value) }
+	public init(_ value: Float) { self = .double(Double(value)) }
+	public init(_ value: Bool) { self = .bool(value) }
+	public init(_ value: Data) { self = .data(value) }
+	public init(_ value: [AttributeValue]) { self = .array(value) }
+	public init(_ value: [String: AttributeValue]) { self = .keyValueList(value) }
+}
+
+// MARK: - AttributeValueRepresentable
+
+/// Types that can be stored as an ``AttributeValue``.
+/// Used by the generic `addAttribute` overload so callers can pass `String`, `Int`, `Bool`, etc. directly.
+public protocol AttributeValueRepresentable: Sendable {
+	var attributeValue: AttributeValue { get }
+}
+
+// MARK: - AttributeValue + AttributeValueRepresentable
+
+extension AttributeValue: AttributeValueRepresentable {
+	public var attributeValue: AttributeValue { self }
+}
+
+// MARK: - String + AttributeValueRepresentable
+
+extension String: AttributeValueRepresentable {
+	public var attributeValue: AttributeValue { .string(self) }
+}
+
+// MARK: - Bool + AttributeValueRepresentable
+
+extension Bool: AttributeValueRepresentable {
+	public var attributeValue: AttributeValue { .bool(self) }
+}
+
+// MARK: - Int + AttributeValueRepresentable
+
+extension Int: AttributeValueRepresentable {
+	public var attributeValue: AttributeValue { .int(Int64(self)) }
+}
+
+// MARK: - Int8 + AttributeValueRepresentable
+
+extension Int8: AttributeValueRepresentable {
+	public var attributeValue: AttributeValue { .int(Int64(self)) }
+}
+
+// MARK: - Int16 + AttributeValueRepresentable
+
+extension Int16: AttributeValueRepresentable {
+	public var attributeValue: AttributeValue { .int(Int64(self)) }
+}
+
+// MARK: - Int32 + AttributeValueRepresentable
+
+extension Int32: AttributeValueRepresentable {
+	public var attributeValue: AttributeValue { .int(Int64(self)) }
+}
+
+// MARK: - Int64 + AttributeValueRepresentable
+
+extension Int64: AttributeValueRepresentable {
+	public var attributeValue: AttributeValue { .int(self) }
+}
+
+// MARK: - UInt + AttributeValueRepresentable
+
+extension UInt: AttributeValueRepresentable {
+	public var attributeValue: AttributeValue { .int(Int64(truncatingIfNeeded: self)) }
+}
+
+// MARK: - UInt8 + AttributeValueRepresentable
+
+extension UInt8: AttributeValueRepresentable {
+	public var attributeValue: AttributeValue { .int(Int64(self)) }
+}
+
+// MARK: - UInt16 + AttributeValueRepresentable
+
+extension UInt16: AttributeValueRepresentable {
+	public var attributeValue: AttributeValue { .int(Int64(self)) }
+}
+
+// MARK: - UInt32 + AttributeValueRepresentable
+
+extension UInt32: AttributeValueRepresentable {
+	public var attributeValue: AttributeValue { .int(Int64(self)) }
+}
+
+// MARK: - UInt64 + AttributeValueRepresentable
+
+extension UInt64: AttributeValueRepresentable {
+	public var attributeValue: AttributeValue { .int(Int64(truncatingIfNeeded: self)) }
+}
+
+// MARK: - Float + AttributeValueRepresentable
+
+extension Float: AttributeValueRepresentable {
+	public var attributeValue: AttributeValue { .double(Double(self)) }
+}
+
+// MARK: - Double + AttributeValueRepresentable
+
+extension Double: AttributeValueRepresentable {
+	public var attributeValue: AttributeValue { .double(self) }
+}
+
+// MARK: - Data + AttributeValueRepresentable
+
+extension Data: AttributeValueRepresentable {
+	public var attributeValue: AttributeValue { .data(self) }
+}
+
+// MARK: - Builder for mixed-type attribute sets
+
+extension [String: AttributeValue] {
+	/// Build a `TelemetryAttributes` grouped by value type. Useful when values are
+	/// typed variables: a dictionary literal like `["k": stringVar, "n": intVar]`
+	/// fails to compile because Swift won't implicitly lift variables to
+	/// `AttributeValue`.
+	///
+	/// ```swift
+	/// TelemetryAttributes(
+	///   string: ["app.release_stage": buildInfo.apiBuildType, "app.language": buildInfo.dynamicLanguageID],
+	///   int: ["retry.attempt": retryAttempt]
+	/// )
+	/// ```
+	///
+	/// Later keys overwrite earlier keys if the same key appears in multiple groups.
+	public init(
+		string: [String: String] = [:],
+		int: [String: Int] = [:],
+		bool: [String: Bool] = [:],
+		double: [String: Double] = [:],
+		data: [String: Data] = [:]
+	) {
+		// Pre-size to avoid rehashing as we merge the groups.
+		self.init(minimumCapacity: string.count + int.count + bool.count + double.count + data.count)
+		for (k, v) in string { self[k] = .string(v) }
+		for (k, v) in int { self[k] = .int(Int64(v)) }
+		for (k, v) in bool { self[k] = .bool(v) }
+		for (k, v) in double { self[k] = .double(v) }
+		for (k, v) in data { self[k] = .data(v) }
+	}
+}

--- a/Sources/NautilusTelemetry/Utilities/AttributeValue.swift
+++ b/Sources/NautilusTelemetry/Utilities/AttributeValue.swift
@@ -93,7 +93,17 @@ extension AttributeValue: ExpressibleByDictionaryLiteral {
 /// The literal conformances above handle the common inline-literal case.
 extension AttributeValue {
 	public init(_ value: String) { self = .string(value) }
-	public init(_ value: some FixedWidthInteger) { self = .int(Int64(truncatingIfNeeded: value)) }
+	public init(_ value: some FixedWidthInteger) {
+		// Values that fit in `Int64` round-trip as JSON numbers; those that don't
+		// (e.g. `Int128`, `UInt64` > `Int64.max`) preserve their value as a JSON
+		// string per ProtoJSON's string fallback for integers beyond IEEE double's
+		// precise range. https://protobuf.dev/programming-guides/json/
+		if let fit = Int64(exactly: value) {
+			self = .int(fit)
+		} else {
+			self = .string("\(value)")
+		}
+	}
 	public init(_ value: Double) { self = .double(value) }
 	public init(_ value: Float) { self = .double(Double(value)) }
 	public init(_ value: Bool) { self = .bool(value) }
@@ -161,7 +171,7 @@ extension Int64: AttributeValueRepresentable {
 // MARK: - UInt + AttributeValueRepresentable
 
 extension UInt: AttributeValueRepresentable {
-	public var attributeValue: AttributeValue { .int(Int64(truncatingIfNeeded: self)) }
+	public var attributeValue: AttributeValue { AttributeValue(self) }
 }
 
 // MARK: - UInt8 + AttributeValueRepresentable
@@ -185,7 +195,7 @@ extension UInt32: AttributeValueRepresentable {
 // MARK: - UInt64 + AttributeValueRepresentable
 
 extension UInt64: AttributeValueRepresentable {
-	public var attributeValue: AttributeValue { .int(Int64(truncatingIfNeeded: self)) }
+	public var attributeValue: AttributeValue { AttributeValue(self) }
 }
 
 // MARK: - Float + AttributeValueRepresentable

--- a/Sources/NautilusTelemetry/Utilities/Identifiers.swift
+++ b/Sources/NautilusTelemetry/Utilities/Identifiers.swift
@@ -12,13 +12,23 @@ import Foundation
 public typealias MetricNumeric = Comparable & Numeric
 
 /// https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/common/README.md#attribute
-public typealias TelemetryAttributes = [String: AnyHashable]
+public typealias TelemetryAttributes = [String: AttributeValue]
 
 // MARK: - TelemetryAttributesContainer
 
 public protocol TelemetryAttributesContainer: AnyObject {
-	func addAttribute(_ name: String, _ value: AnyHashable?)
-	subscript(_: String) -> AnyHashable? { get set }
+	func addAttribute(_ name: String, _ value: AttributeValue?)
+	subscript(_: String) -> AttributeValue? { get set }
+}
+
+extension TelemetryAttributesContainer {
+	/// Adds an attribute from any `AttributeValueRepresentable` value (e.g. `String`,
+	/// `Int`, `Bool`, `Data`). Convenient when the value is a typed variable
+	/// rather than a literal: literals route directly through the primary
+	/// `addAttribute(_:AttributeValue?)` via `ExpressibleByStringLiteral`/etc.
+	public func addAttribute(_ name: String, _ value: (some AttributeValueRepresentable)?) {
+		addAttribute(name, value?.attributeValue)
+	}
 }
 
 // These could be converted to UInt128 / UInt64, once UInt128 is widely available

--- a/Sources/SampleCode/ExampleReporter.swift
+++ b/Sources/SampleCode/ExampleReporter.swift
@@ -51,7 +51,7 @@ public class ExampleReporter: NautilusTelemetryReporter {
 		let filtered = sampledSpans(spans)
 		guard !filtered.isEmpty else { return }
 
-		let additionalAttributes = ["sample": "value"]
+		let additionalAttributes: TelemetryAttributes = ["sample": "value"]
 		let exporter = Exporter(timeReference: timeReference)
 
 		if let jsonPayload = try? exporter.exportOTLPToJSON(spans: filtered, additionalAttributes: additionalAttributes) {
@@ -64,7 +64,7 @@ public class ExampleReporter: NautilusTelemetryReporter {
 			return
 		}
 
-		let additionalAttributes = ["sample": "value"]
+		let additionalAttributes: TelemetryAttributes = ["sample": "value"]
 		let exporter = Exporter(timeReference: timeReference)
 
 		if let jsonPayload = try? exporter.exportOTLPToJSON(instruments: instruments, additionalAttributes: additionalAttributes) {

--- a/Tests/NautilusTelemetryPerformanceTests/MetricValuesPerformanceTests.swift
+++ b/Tests/NautilusTelemetryPerformanceTests/MetricValuesPerformanceTests.swift
@@ -1,0 +1,65 @@
+//
+//  MetricValuesPerformanceTests.swift
+//
+//
+//  Created by Ladd Van Tol on 2026-05-01.
+//
+
+import Foundation
+import XCTest
+
+@testable import NautilusTelemetry
+
+/// Micro-benchmarks for the hot attribute-sink paths: `MetricValues.add`,
+/// `HistogramValues.record`, and `ExponentialHistogramValues.record`.
+/// These are where a caller-built `TelemetryAttributes` dictionary flows into
+/// the instrument on every `Counter.add` / `Histogram.record` / `ExponentialHistogram.record`.
+final class MetricValuesPerformanceTests: XCTestCase {
+
+	static let iterations = 100_000
+
+	/// ≈580 ns/call on M4 Max (down from ≈634 ns with `AnyHashable`).
+	func testCounterAddPerformance() {
+		let counter = Counter<Int>(name: "test", unit: nil, description: nil)
+		let attributes: TelemetryAttributes = ["endpoint": "/foo", "status": 200, "region": "us-east-1"]
+
+		measure {
+			for _ in 0..<Self.iterations {
+				counter.add(1, attributes: attributes)
+			}
+		}
+	}
+
+	/// ≈670 ns/call on M4 Max (down from ≈727 ns with `AnyHashable`).
+	func testHistogramRecordPerformance() {
+		let histogram = Histogram<Double>(
+			name: "test",
+			unit: nil,
+			description: nil,
+			explicitBounds: [0.01, 0.1, 1, 10, 100]
+		)
+		let attributes: TelemetryAttributes = ["endpoint": "/foo", "status": 200, "region": "us-east-1"]
+
+		measure {
+			for _ in 0..<Self.iterations {
+				histogram.record(0.42, attributes: attributes)
+			}
+		}
+	}
+
+	/// ≈6.12 µs/call on M4 Max (down from ≈6.23 µs with `AnyHashable`).
+	/// Dominated by `recordedValues.append(Double)`; the attribute-hash improvement
+	/// contributes only a small fraction of the wall clock.
+	func testExponentialHistogramRecordPerformance() {
+		let attributes: TelemetryAttributes = ["endpoint": "/foo", "status": 200, "region": "us-east-1"]
+
+		measure {
+			// Fresh histogram per iteration so `recordedValues` array doesn't grow unboundedly
+			// across measurement runs.
+			let histogram = ExponentialHistogram<Double>(name: "test", unit: nil, description: nil)
+			for _ in 0..<Self.iterations {
+				histogram.record(0.42, attributes: attributes)
+			}
+		}
+	}
+}

--- a/Tests/NautilusTelemetryTests/Exporters/ExporterTests.swift
+++ b/Tests/NautilusTelemetryTests/Exporters/ExporterTests.swift
@@ -16,59 +16,38 @@ final class ExporterTests: XCTestCase {
 	func testConvertToOTLPString() throws {
 		let exporter = Exporter(timeReference: timeReference, prettyPrint: false)
 
-		let string = "abc"
-		let stringVal = try XCTUnwrap(exporter.convertToOTLP(value: string))
-		XCTAssertEqual(stringVal.stringValue, "abc")
+		let value = exporter.convertToOTLP(value: .string("abc"))
+		XCTAssertEqual(value.stringValue, "abc")
 	}
 
 	func testConvertToOTLPBool() throws {
 		let exporter = Exporter(timeReference: timeReference, prettyPrint: false)
 
-		let bool1 = true
-		let boolVal1 = try XCTUnwrap(exporter.convertToOTLP(value: bool1))
-		XCTAssertEqual(boolVal1.boolValue, true)
-
-		let bool2 = false
-		let boolVal2 = try XCTUnwrap(exporter.convertToOTLP(value: bool2))
-		XCTAssertEqual(boolVal2.boolValue, false)
+		XCTAssertEqual(exporter.convertToOTLP(value: .bool(true)).boolValue, true)
+		XCTAssertEqual(exporter.convertToOTLP(value: .bool(false)).boolValue, false)
 	}
 
-	func testConvertToOTLPFloats() throws {
+	func testConvertToOTLPDouble() throws {
 		let exporter = Exporter(timeReference: timeReference, prettyPrint: false)
 
-		let float = Float(100)
-		let floatValue = try XCTUnwrap(exporter.convertToOTLP(value: float))
-		XCTAssertEqual(Float(try XCTUnwrap(floatValue.doubleValue)), float)
+		// `AttributeValue` always stores floating-point values as `Double`.
+		let value = exporter.convertToOTLP(value: AttributeValue(Float(100)))
+		XCTAssertEqual(Float(try XCTUnwrap(value.doubleValue)), 100)
 
-		let double = Double(32)
-		let doubleValue = try XCTUnwrap(exporter.convertToOTLP(value: double))
-		XCTAssertEqual(doubleValue.doubleValue, double)
+		XCTAssertEqual(exporter.convertToOTLP(value: .double(32)).doubleValue, 32)
 	}
 
 	func testConvertToOTLPIntegers() throws {
 		let exporter = Exporter(timeReference: timeReference, prettyPrint: false)
 
-		let uint64 = UInt64.max
-		let intValue1 = try XCTUnwrap(exporter.convertToOTLP(value: uint64))
-		XCTAssertEqual(try XCTUnwrap(intValue1.intValue as? UInt64), uint64)
-
+		// AttributeValue normalizes integers to `Int64`. Very large `UInt64` values
+		// that exceed `Int64.max` will be bit-equivalent but interpreted as negative.
 		let int64 = Int64.max
-		let intValue2 = try XCTUnwrap(exporter.convertToOTLP(value: int64))
-		XCTAssertEqual(try XCTUnwrap(intValue2.intValue as? Int64), int64)
+		XCTAssertEqual(exporter.convertToOTLP(value: .int(int64)).intValue, int64)
 
-		let uint32 = UInt32.max
-		let intValue3 = try XCTUnwrap(exporter.convertToOTLP(value: uint32))
-		XCTAssertEqual(try XCTUnwrap(intValue3.intValue as? UInt32), uint32)
-
-		// make sure we don't cast to Bool accidentally
-		let uint: UInt = 0
-		let intValue4 = try XCTUnwrap(exporter.convertToOTLP(value: uint))
-		XCTAssertEqual(try XCTUnwrap(intValue4.intValue as? UInt), uint)
-		XCTAssertNil(intValue4.boolValue)
-
-		let int32 = Int32.max
-		let intValue5 = try XCTUnwrap(exporter.convertToOTLP(value: int32))
-		XCTAssertEqual(try XCTUnwrap(intValue5.intValue as? Int32), int32)
+		XCTAssertEqual(exporter.convertToOTLP(value: AttributeValue(UInt32.max)).intValue, Int64(UInt32.max))
+		XCTAssertEqual(exporter.convertToOTLP(value: AttributeValue(Int32.max)).intValue, Int64(Int32.max))
+		XCTAssertEqual(exporter.convertToOTLP(value: AttributeValue(UInt(0))).intValue, 0)
 	}
 
 	func testJSONEncoding() throws {
@@ -76,7 +55,7 @@ final class ExporterTests: XCTestCase {
 
 		// Check a normal case
 		do {
-			let normalAnyValue = try XCTUnwrap(exporter.convertToOTLP(value: 0))
+			let normalAnyValue = exporter.convertToOTLP(value: .int(0))
 			let encoded = try JSONEncoder().encode(normalAnyValue)
 			let encodedString = String(data: encoded, encoding: .utf8)
 			XCTAssertEqual(encodedString, #"{"intValue":0}"#)
@@ -84,76 +63,57 @@ final class ExporterTests: XCTestCase {
 
 		// Check that ints in the bound are expressed as JSON numbers
 		do {
-			let lowerIntBound = -(1 << 53)
-			let lowerIntBoundAnyValue = try XCTUnwrap(exporter.convertToOTLP(value: lowerIntBound))
-			let encoded = try JSONEncoder().encode(lowerIntBoundAnyValue)
+			let lowerIntBound: Int64 = -(1 << 53)
+			let v = exporter.convertToOTLP(value: .int(lowerIntBound))
+			let encoded = try JSONEncoder().encode(v)
 			let encodedString = String(data: encoded, encoding: .utf8)
 			XCTAssertEqual(encodedString, #"{"intValue":-9007199254740992}"#)
 		}
 
 		do {
-			let upperIntBound = (1 << 53)
-			let upperIntBoundAnyIntValue = try XCTUnwrap(exporter.convertToOTLP(value: upperIntBound))
-			let encoded = try JSONEncoder().encode(upperIntBoundAnyIntValue)
+			let upperIntBound: Int64 = (1 << 53)
+			let v = exporter.convertToOTLP(value: .int(upperIntBound))
+			let encoded = try JSONEncoder().encode(v)
 			let encodedString = String(data: encoded, encoding: .utf8)
 			XCTAssertEqual(encodedString, #"{"intValue":9007199254740992}"#)
 		}
 
 		// Check that ints outside the bound are expressed as JSON strings
 		do {
-			let lowerIntBound = -(1 << 53) - 1
-			let lowerIntBoundAnyValue = try XCTUnwrap(exporter.convertToOTLP(value: lowerIntBound))
-			let encoded = try JSONEncoder().encode(lowerIntBoundAnyValue)
+			let lowerIntBound: Int64 = -(1 << 53) - 1
+			let v = exporter.convertToOTLP(value: .int(lowerIntBound))
+			let encoded = try JSONEncoder().encode(v)
 			let encodedString = String(data: encoded, encoding: .utf8)
 			XCTAssertEqual(encodedString, #"{"intValue":"-9007199254740993"}"#)
 		}
 
 		do {
-			let upperIntBound = (1 << 53) + 1
-			let upperIntBoundAnyIntValue = try XCTUnwrap(exporter.convertToOTLP(value: upperIntBound))
-			let encoded = try JSONEncoder().encode(upperIntBoundAnyIntValue)
+			let upperIntBound: Int64 = (1 << 53) + 1
+			let v = exporter.convertToOTLP(value: .int(upperIntBound))
+			let encoded = try JSONEncoder().encode(v)
 			let encodedString = String(data: encoded, encoding: .utf8)
 			XCTAssertEqual(encodedString, #"{"intValue":"9007199254740993"}"#)
 		}
-
-		// Check Int128 support
-		// The GitHub CI machine runs macOS 14.5, but I need a compile time check
-//		do {
-//			if #available(iOS 18.0, macOS 15.0, *) {
-//				let upperIntBound = Int128.max
-//				let upperIntBoundAnyIntValue = try XCTUnwrap(exporter.convertToOTLP(value: upperIntBound))
-//				let encoded = try JSONEncoder().encode(upperIntBoundAnyIntValue)
-//				let encodedString = String(data: encoded, encoding: .utf8)
-//				XCTAssertEqual(encodedString, #"{"intValue":"170141183460469231731687303715884105727"}"#)
-//			}
-//		}
 	}
 
 	func testConvertToOTLPComplexTypes() throws {
 		let exporter = Exporter(timeReference: timeReference, prettyPrint: false)
 		let data = try XCTUnwrap("📀".data(using: .utf8))
-		let dataValue = try XCTUnwrap(exporter.convertToOTLP(value: data))
+		let dataValue = exporter.convertToOTLP(value: .data(data))
 		XCTAssertEqual(dataValue.bytesValue, data)
 		let encodedJsonString = String(data: try exporter.encodeJSON(dataValue), encoding: .utf8)
 		XCTAssertEqual(encodedJsonString, #"{"bytesValue":"f09f9380"}"#)
 
-		let array: [Any] = ["foo", 1]
-		let arrayValue = try XCTUnwrap(exporter.convertToOTLP(value: array))
+		let array: AttributeValue = [.string("foo"), .int(1)]
+		let arrayValue = exporter.convertToOTLP(value: array)
 		let values = try XCTUnwrap(arrayValue.arrayValue?.values)
-		let value0 = values[0]
-		XCTAssertEqual("foo", value0.stringValue)
-		let value1 = values[1]
-		XCTAssertEqual(1, value1.intValue as? Int)
+		XCTAssertEqual(values[0].stringValue, "foo")
+		XCTAssertEqual(values[1].intValue, 1)
 
-		let dictionary = ["foo": 1]
-		let dictionaryValue = try XCTUnwrap(exporter.convertToOTLP(value: dictionary))
-		let kvValue = try XCTUnwrap(dictionaryValue.kvlistValue?.values?[0])
-		XCTAssertEqual(kvValue.key, "foo")
-		XCTAssertEqual(kvValue.value?.intValue as? Int, 1)
-
-		let notConvertible = self
-		let notConvertibleValue = exporter.convertToOTLP(value: notConvertible)
-		XCTAssertNil(notConvertibleValue)
+		let dictionary: AttributeValue = ["foo": .int(1)]
+		let dictionaryValue = exporter.convertToOTLP(value: dictionary)
+		let kvValue = try XCTUnwrap(dictionaryValue.kvlistValue?.values?.first { $0.key == "foo" })
+		XCTAssertEqual(kvValue.value?.intValue, 1)
 	}
 
 	func testAsDoubleHelper() throws {
@@ -223,20 +183,8 @@ final class ExporterTests: XCTestCase {
 		XCTAssertEqual(result[0].key, "apple")
 		XCTAssertEqual(result[0].value?.stringValue, "first")
 		XCTAssertEqual(result[1].key, "middle")
-		XCTAssertEqual(result[1].value?.intValue as? Int, 123)
+		XCTAssertEqual(result[1].value?.intValue, 123)
 		XCTAssertEqual(result[2].key, "zebra")
 		XCTAssertEqual(result[2].value?.stringValue, "last")
-
-		// Test nil filtering
-		let nilValue: String? = nil
-		let attributesWithNil: TelemetryAttributes = [
-			"valid": "value",
-			"invalid": AnyHashable(nilValue),
-		]
-
-		let filteredResult = try XCTUnwrap(exporter.convertToOTLP(attributes: attributesWithNil))
-		XCTAssertEqual(filteredResult.count, 1)
-		XCTAssertEqual(filteredResult[0].key, "valid")
-		XCTAssertEqual(filteredResult[0].value?.stringValue, "value")
 	}
 }

--- a/Tests/NautilusTelemetryTests/Metrics/CounterTests.swift
+++ b/Tests/NautilusTelemetryTests/Metrics/CounterTests.swift
@@ -236,7 +236,7 @@ final class CounterTests: XCTestCase {
 			let attributes: TelemetryAttributes = [
 				"method": i % 2 == 0 ? "GET" : "POST",
 				"status": i % 3 == 0 ? "success" : "error",
-				"index": i,
+				"index": AttributeValue(i),
 			]
 			counter.add(i + 1, attributes: attributes)
 		}

--- a/Tests/NautilusTelemetryTests/Metrics/HistogramTests.swift
+++ b/Tests/NautilusTelemetryTests/Metrics/HistogramTests.swift
@@ -235,7 +235,7 @@ final class HistogramTests: XCTestCase {
 			let attributes: TelemetryAttributes = [
 				"service": i % 2 == 0 ? "api" : "web",
 				"status": i % 3 == 0 ? "success" : "error",
-				"index": i,
+				"index": AttributeValue(i),
 			]
 			histogram.record(i + 1, attributes: attributes)
 		}

--- a/Tests/NautilusTelemetryTests/Metrics/HistogramValuesTests.swift
+++ b/Tests/NautilusTelemetryTests/Metrics/HistogramValuesTests.swift
@@ -315,7 +315,7 @@ final class HistogramValuesTests: XCTestCase {
 			let attributes: TelemetryAttributes = [
 				"service": i % 2 == 0 ? "api" : "web",
 				"status": i % 3 == 0 ? "success" : "error",
-				"index": i,
+				"index": AttributeValue(i),
 			]
 			histogramValues.record(i + 1, attributes: attributes)
 		}

--- a/Tests/NautilusTelemetryTests/Metrics/MetricValuesTests.swift
+++ b/Tests/NautilusTelemetryTests/Metrics/MetricValuesTests.swift
@@ -324,12 +324,12 @@ final class MetricValuesTests: XCTestCase {
 
 		// Test with many different attribute combinations
 		for i in 0..<100 {
-			let attributes: TelemetryAttributes = ["index": i]
+			let attributes: TelemetryAttributes = ["index": AttributeValue(i)]
 			metrics.add(i, attributes: attributes)
 		}
 
 		for i in 0..<100 {
-			let attributes: TelemetryAttributes = ["index": i]
+			let attributes: TelemetryAttributes = ["index": AttributeValue(i)]
 			XCTAssertEqual(metrics.valueFor(attributes: attributes), i)
 		}
 

--- a/Tests/NautilusTelemetryTests/Metrics/ObservableCounterTests.swift
+++ b/Tests/NautilusTelemetryTests/Metrics/ObservableCounterTests.swift
@@ -303,7 +303,7 @@ final class ObservableCounterTests: XCTestCase {
 		// Simulate concurrent observe operations with different attributes
 		for i in 1...10 {
 			DispatchQueue.global().async {
-				let attributes: TelemetryAttributes = ["thread": i]
+				let attributes: TelemetryAttributes = ["thread": AttributeValue(i)]
 				counter.observe(i * 10, attributes: attributes)
 				expectation.fulfill()
 			}
@@ -326,7 +326,7 @@ final class ObservableCounterTests: XCTestCase {
 			let attributes: TelemetryAttributes = [
 				"service": i % 2 == 0 ? "api" : "web",
 				"status": i % 3 == 0 ? "success" : "error",
-				"index": i,
+				"index": AttributeValue(i),
 			]
 			counter.observe((i + 1) * 10, attributes: attributes)
 		}

--- a/Tests/NautilusTelemetryTests/Metrics/ObservableGaugeTests.swift
+++ b/Tests/NautilusTelemetryTests/Metrics/ObservableGaugeTests.swift
@@ -289,7 +289,7 @@ final class ObservableGaugeTests: XCTestCase {
 		// Simulate concurrent observe operations with different attributes
 		for i in 1...10 {
 			DispatchQueue.global().async {
-				let attributes: TelemetryAttributes = ["sensor": i]
+				let attributes: TelemetryAttributes = ["sensor": AttributeValue(i)]
 				gauge.observe(i * 10, attributes: attributes)
 				expectation.fulfill()
 			}
@@ -312,7 +312,7 @@ final class ObservableGaugeTests: XCTestCase {
 			let attributes: TelemetryAttributes = [
 				"host": i % 2 == 0 ? "server1" : "server2",
 				"metric": i % 3 == 0 ? "cpu" : "memory",
-				"index": i,
+				"index": AttributeValue(i),
 			]
 			gauge.observe((i + 1) * 10, attributes: attributes)
 		}

--- a/Tests/NautilusTelemetryTests/Metrics/ObservableUpDownCounterTests.swift
+++ b/Tests/NautilusTelemetryTests/Metrics/ObservableUpDownCounterTests.swift
@@ -325,7 +325,7 @@ final class ObservableUpDownCounterTests: XCTestCase {
 		// Simulate concurrent observe operations with different attributes
 		for i in 1...10 {
 			DispatchQueue.global().async {
-				let attributes: TelemetryAttributes = ["thread": i]
+				let attributes: TelemetryAttributes = ["thread": AttributeValue(i)]
 				// Mix positive and negative values
 				let value = i % 2 == 0 ? i * 10 : -(i * 10)
 				counter.observe(value, attributes: attributes)
@@ -350,7 +350,7 @@ final class ObservableUpDownCounterTests: XCTestCase {
 			let attributes: TelemetryAttributes = [
 				"service": i % 2 == 0 ? "api" : "web",
 				"status": i % 3 == 0 ? "success" : "error",
-				"index": i,
+				"index": AttributeValue(i),
 			]
 			// Mix positive and negative values
 			let value = i % 2 == 0 ? (i + 1) * 10 : -((i + 1) * 10)

--- a/Tests/NautilusTelemetryTests/Metrics/SnapshotAndResetTests.swift
+++ b/Tests/NautilusTelemetryTests/Metrics/SnapshotAndResetTests.swift
@@ -47,10 +47,10 @@ final class SnapshotAndResetTests: XCTestCase {
 		}
 		XCTAssertEqual(snapshotCounter.values.values.count, 2)
 		XCTAssertTrue(snapshotCounter.values.values.contains { attributes, value in
-			value == 100 && attributes["key1"] as? String == "value1"
+			value == 100 && attributes["key1"]?.stringValue == "value1"
 		})
 		XCTAssertTrue(snapshotCounter.values.values.contains { attributes, value in
-			value == 200 && attributes["key2"] as? String == "value2"
+			value == 200 && attributes["key2"]?.stringValue == "value2"
 		})
 
 		// Verify original counter is reset
@@ -206,7 +206,7 @@ final class SnapshotAndResetTests: XCTestCase {
 		}
 		XCTAssertFalse(snapshotCounter.values.values.isEmpty)
 		XCTAssertTrue(snapshotCounter.values.values.contains { attributes, value in
-			value == 500 && attributes["source"] as? String == "callback"
+			value == 500 && attributes["source"]?.stringValue == "callback"
 		})
 
 		// Verify original counter is reset
@@ -312,7 +312,7 @@ final class SnapshotAndResetTests: XCTestCase {
 		}
 		XCTAssertFalse(snapshotGauge.values.values.isEmpty)
 		XCTAssertTrue(snapshotGauge.values.values.contains { attributes, value in
-			value == 750 && attributes["measurement"] as? String == "current"
+			value == 750 && attributes["measurement"]?.stringValue == "current"
 		})
 
 		// Verify original gauge is reset
@@ -395,7 +395,7 @@ final class SnapshotAndResetTests: XCTestCase {
 			return
 		}
 		XCTAssertTrue(snapshotCounter.values.values.contains { attributes, value in
-			value == 1.5 && attributes["precision"] as? String == "high"
+			value == 1.5 && attributes["precision"]?.stringValue == "high"
 		})
 	}
 

--- a/Tests/NautilusTelemetryTests/Metrics/UpDownCounterTests.swift
+++ b/Tests/NautilusTelemetryTests/Metrics/UpDownCounterTests.swift
@@ -271,7 +271,7 @@ final class UpDownCounterTests: XCTestCase {
 			let attributes: TelemetryAttributes = [
 				"service": i % 2 == 0 ? "api" : "web",
 				"operation": i % 3 == 0 ? "create" : "delete",
-				"index": i,
+				"index": AttributeValue(i),
 			]
 			// Mix positive and negative values
 			let value = i % 2 == 0 ? (i + 1) : -(i + 1)

--- a/Tests/NautilusTelemetryTests/TestingUtilities/TestUtils.swift
+++ b/Tests/NautilusTelemetryTests/TestingUtilities/TestUtils.swift
@@ -8,6 +8,37 @@ import XCTest
 
 @testable import NautilusTelemetry
 
+// MARK: - AttributeValue test helpers
+
+extension AttributeValue {
+	/// Unwraps `.string(_)` payload for tests. Returns nil for any other case.
+	var stringPayload: String? {
+		if case .string(let v) = self { v } else { nil }
+	}
+
+	/// Unwraps `.int(_)` payload for tests. Returns nil for any other case.
+	var intPayload: Int64? {
+		if case .int(let v) = self { v } else { nil }
+	}
+
+	/// Unwraps `.double(_)` payload for tests. Returns nil for any other case.
+	var doublePayload: Double? {
+		if case .double(let v) = self { v } else { nil }
+	}
+
+	/// Unwraps `.bool(_)` payload for tests. Returns nil for any other case.
+	var boolPayload: Bool? {
+		if case .bool(let v) = self { v } else { nil }
+	}
+
+	/// Unwraps `.data(_)` payload for tests. Returns nil for any other case.
+	var dataPayload: Data? {
+		if case .data(let v) = self { v } else { nil }
+	}
+}
+
+// MARK: - TestUtils
+
 enum TestUtils {
 
 	enum UtilError: Error {
@@ -31,18 +62,18 @@ enum TestUtils {
 		fragment: .optional
 	)
 
-	static var additionalAttributes: [String: String] {
+	static var additionalAttributes: TelemetryAttributes {
 		get throws {
 			guard let env = ProcessInfo.processInfo.environment["additionalAttributes"] else { return [:] }
 
-			var dictionary = [String: String]()
+			var dictionary = TelemetryAttributes()
 
 			let elements = env.split(separator: ",")
 
 			for element in elements {
 				let pair = element.split(separator: "=")
 				if pair.count == 2 {
-					dictionary[String(pair[0])] = String(pair[1])
+					dictionary[String(pair[0])] = .string(String(pair[1]))
 				}
 			}
 

--- a/Tests/NautilusTelemetryTests/Tracing/Span+URLSessionTests.swift
+++ b/Tests/NautilusTelemetryTests/Tracing/Span+URLSessionTests.swift
@@ -35,7 +35,7 @@ final class SpanURLSessionTests: XCTestCase {
 		span.urlSession(urlSession, didCreateTask: task, captureHeaders: Set(["content-type"]))
 
 		let attributes = try XCTUnwrap(span.attributes)
-		XCTAssertEqual(attributes["url.full"], url.absoluteString)
+		XCTAssertEqual(attributes["url.full"], .string(url.absoluteString))
 		XCTAssertEqual(attributes["http.request.header.content-type"], "application/json")
 	}
 
@@ -56,7 +56,7 @@ final class SpanURLSessionTests: XCTestCase {
 		let exceptionEvent = try XCTUnwrap(span.events?.first)
 		let exceptionAttributes = try XCTUnwrap(exceptionEvent.attributes)
 		XCTAssertEqual(exceptionAttributes["exception.type"], "NSError.test.1")
-		XCTAssertEqual(exceptionAttributes["exception.message"], message)
+		XCTAssertEqual(exceptionAttributes["exception.message"], .string(message))
 	}
 
 	// URLSessionTaskMetrics is annoying to mock
@@ -133,7 +133,7 @@ final class SpanURLSessionTests: XCTestCase {
 		span.addRequestAttributes(urlRequest)
 
 		let attributes = try XCTUnwrap(span.attributes)
-		XCTAssertEqual(attributes["url.scheme"], url.scheme)
+		XCTAssertEqual(attributes["url.scheme"], url.scheme.map { .string($0) })
 	}
 
 	func testCustomUrlRedaction() throws {
@@ -185,7 +185,7 @@ final class SpanURLSessionTests: XCTestCase {
 		span.urlSession(urlSession, didCreateTask: task)
 
 		let attributes = try XCTUnwrap(span.attributes)
-		XCTAssertEqual(attributes["http.priority"], task.priority)
+		XCTAssertEqual(attributes["http.priority"], .double(Double(task.priority)))
 	}
 
 }

--- a/Tests/NautilusTelemetryTests/Tracing/SpanTests.swift
+++ b/Tests/NautilusTelemetryTests/Tracing/SpanTests.swift
@@ -94,11 +94,11 @@ struct SpanTests {
 		let span1 = tracer.retiredSpans[1]
 		#expect(span1.status == .error(message: "failure"))
 
-		let exceptionType = try #require(span1.events?[0].attributes?["exception.type"] as? String)
+		let exceptionType = try #require(span1.events?[0].attributes?["exception.type"]?.stringPayload)
 		#expect(exceptionType == "NautilusTelemetryTests.SpanTests.TestError")
 
 		let event = span1.events?[0]
-		let backtrace = try #require(event?.attributes?["exception.stacktrace"] as? String)
+		let backtrace = try #require(event?.attributes?["exception.stacktrace"]?.stringPayload)
 		#expect(backtrace.contains("traceWithError"))
 
 		let traceParentHeader = span2.traceParentHeaderValue(sampled: false)
@@ -156,9 +156,13 @@ struct SpanTests {
 
 	@Test
 	func asyncSpan() async throws {
+		// Verifies the async `withSpan` overload: the block must perform a real
+		// `await` so Swift resolves to the `async` variant (otherwise the call
+		// would fall back to the synchronous overload and emit "no 'async'
+		// operations occur within 'await' expression").
 		try await tracer.withSpan(name: "span1") {
 			#expect(tracer.currentBaggage.span.parentId != nil)
-			try span2Run()
+			try await asyncSpan2Run()
 		}
 
 		#expect(tracer.retiredSpans.count == 2)
@@ -174,6 +178,21 @@ struct SpanTests {
 			let span = tracer.currentBaggage.span
 			span.addEvent("event1")
 			Thread.sleep(forTimeInterval: 0.1)
+			span.addEvent("event2")
+			span.status = .ok
+			ranSpan = true
+		}
+		#expect(ranSpan)
+	}
+
+	func asyncSpan2Run() async throws {
+		var ranSpan = false
+		try await tracer.withSpan(name: "span2") {
+			let span = tracer.currentBaggage.span
+			span.addEvent("event1")
+			// `Task.sleep` is a genuine suspension point, unlike `Thread.sleep`,
+			// so this block actually exercises the `async` `withSpan` overload.
+			try await Task.sleep(for: .milliseconds(100))
 			span.addEvent("event2")
 			span.status = .ok
 			ranSpan = true
@@ -215,8 +234,8 @@ struct SpanTests {
 		let exceptionEvent = try #require(span.events?.first)
 		let exceptionAttributes = try #require(exceptionEvent.attributes)
 		#expect(span.status == .error(message: "NSFailed"))
-		#expect(exceptionAttributes["exception.type"] as? String == "NSError.VeryBadError.-42")
-		#expect(exceptionAttributes["exception.message"] as? String == "NSFailed")
+		#expect(exceptionAttributes["exception.type"]?.stringPayload == "NSError.VeryBadError.-42")
+		#expect(exceptionAttributes["exception.message"]?.stringPayload == "NSFailed")
 	}
 
 	@Test
@@ -228,8 +247,8 @@ struct SpanTests {
 		let exceptionEvent = try #require(span.events?.first)
 		let exceptionAttributes = try #require(exceptionEvent.attributes)
 		#expect(span.status == .error(message: "failure"))
-		#expect(exceptionAttributes["exception.type"] as? String == "NautilusTelemetryTests.SpanTests.TestError")
-		#expect(exceptionAttributes["exception.message"] as? String == "failure")
+		#expect(exceptionAttributes["exception.type"]?.stringPayload == "NautilusTelemetryTests.SpanTests.TestError")
+		#expect(exceptionAttributes["exception.message"]?.stringPayload == "failure")
 	}
 
 	@Test
@@ -240,8 +259,8 @@ struct SpanTests {
 		let exceptionEvent = try #require(span.events?.first)
 		let exceptionAttributes = try #require(exceptionEvent.attributes)
 		#expect(span.status == .error(message: "custom error message"))
-		#expect(exceptionAttributes["exception.type"] as? String == "custom")
-		#expect(exceptionAttributes["exception.message"] as? String == "custom error message")
+		#expect(exceptionAttributes["exception.type"]?.stringPayload == "custom")
+		#expect(exceptionAttributes["exception.message"]?.stringPayload == "custom error message")
 	}
 
 	@Test
@@ -311,7 +330,7 @@ struct SpanTests {
 	func spanSubscript() {
 		let span = tracer.startSpan(name: "test")
 		span["key1"] = "value1"
-		#expect(span["key1"] as? String == "value1")
+		#expect(span["key1"] == "value1")
 	}
 
 	@Test

--- a/Tests/NautilusTelemetryTests/Tracing/TraceExporterTests.swift
+++ b/Tests/NautilusTelemetryTests/Tracing/TraceExporterTests.swift
@@ -55,7 +55,7 @@ final class TraceExporterTests: XCTestCase {
 		}
 
 		let tracer = Tracer()
-		tracer.withSpan(name: "span1", attributes: ["small integer": 42, "large integer": 2 << 54]) {
+		tracer.withSpan(name: "span1", attributes: ["small integer": 42, "large integer": .int(2 << 54)]) {
 			tracer.withSpan(name: "span2") {
 				let span2 = tracer.currentBaggage.span
 				span2.addEvent("event1")
@@ -161,10 +161,10 @@ final class TraceExporterTests: XCTestCase {
 						//	"activity": logEntry.activityIdentifier,
 						//	"thread": logEntry.threadIdentifier,
 
-						"category": logEntry.category,
-						"process": logEntry.process,
-						"sender": logEntry.sender,
-						"subsystem": logEntry.subsystem,
+						"category": .string(logEntry.category),
+						"process": .string(logEntry.process),
+						"sender": .string(logEntry.sender),
+						"subsystem": .string(logEntry.subsystem),
 					]
 
 					let attributesKV = exporter.convertToOTLP(attributes: attributes)

--- a/Tests/NautilusTelemetryTests/Tracing/Tracer+MetricsTests.swift
+++ b/Tests/NautilusTelemetryTests/Tracing/Tracer+MetricsTests.swift
@@ -132,7 +132,7 @@ struct TracerMetricsTests {
 		span.addAttribute("c", 3)
 
 		let filtered = Tracer.collectAttributes(span, Set(["a", "c"]))
-		#expect(filtered == ["a": AnyHashable(1), "c": AnyHashable(3)])
+		#expect(filtered == ["a": 1, "c": 3])
 	}
 
 	@Test

--- a/Tests/NautilusTelemetryTests/Tracing/Tracer+URLRequestTests.swift
+++ b/Tests/NautilusTelemetryTests/Tracing/Tracer+URLRequestTests.swift
@@ -29,9 +29,9 @@ final class TracerURLRequestTests: XCTestCase {
 		for span in spans {
 			XCTAssertEqual(span.name, "GET /users/:id")
 
-			let attributes = try XCTUnwrap(span.attributes as? [String: String])
-			XCTAssertEqual(attributes["server.address"], url.host())
-			XCTAssertEqual(attributes["http.request.method"], urlRequest.httpMethod)
+			let attributes = try XCTUnwrap(span.attributes)
+			XCTAssertEqual(attributes["server.address"]?.stringValue, url.host())
+			XCTAssertEqual(attributes["http.request.method"]?.stringValue, urlRequest.httpMethod)
 			XCTAssertEqual(attributes["http.request.header.content-type"], "application/json")
 			XCTAssertEqual(attributes["url.template"], "/users/:id")
 		}

--- a/Tests/NautilusTelemetryTests/Tracing/TracerTests.swift
+++ b/Tests/NautilusTelemetryTests/Tracing/TracerTests.swift
@@ -138,7 +138,7 @@ struct TracerTests {
 		baggage["baggage.key"] = "baggage.value"
 
 		let child = tracer.buildSpan(name: "child", baggage: baggage)
-		#expect(child["baggage.key"] as? String == "baggage.value")
+		#expect(child["baggage.key"] == "baggage.value")
 	}
 
 	@Test
@@ -149,7 +149,7 @@ struct TracerTests {
 
 		let spanAttributes: TelemetryAttributes = ["shared.key": "from.span"]
 		let child = tracer.buildSpan(name: "child", attributes: spanAttributes, baggage: baggage)
-		#expect(child["shared.key"] as? String == "from.span")
+		#expect(child["shared.key"] == "from.span")
 	}
 
 	@Test
@@ -161,14 +161,14 @@ struct TracerTests {
 	func mergeAttributesBaggageOnlyNil() {
 		let spanAttributes: TelemetryAttributes = ["span.key": "span.value"]
 		let result = tracer.mergeAttributes(baggageAttributes: nil, spanAttributes: spanAttributes)
-		#expect(result?["span.key"] as? String == "span.value")
+		#expect(result?["span.key"] == "span.value")
 	}
 
 	@Test
 	func mergeAttributesSpanOnlyNil() {
 		let baggageAttributes: TelemetryAttributes = ["baggage.key": "baggage.value"]
 		let result = tracer.mergeAttributes(baggageAttributes: baggageAttributes, spanAttributes: nil)
-		#expect(result?["baggage.key"] as? String == "baggage.value")
+		#expect(result?["baggage.key"] == "baggage.value")
 	}
 
 	// MARK: - Error Propagation Tests

--- a/Tests/NautilusTelemetryTests/Utilities/AttributeValueTests.swift
+++ b/Tests/NautilusTelemetryTests/Utilities/AttributeValueTests.swift
@@ -53,6 +53,21 @@ struct AttributeValueTests {
 		#expect(AttributeValue(Int64(-1)) == .int(-1))
 	}
 
+	/// Integers that don't fit in `Int64` fall back to `.string(...)` so no value is
+	/// lost (matches the ProtoJSON string-fallback behavior). Exercises both sides
+	/// of the `Int64(exactly:)` guard in `AttributeValue.init(_:FixedWidthInteger)`.
+	@Test
+	func oversizedIntegerFallsBackToString() {
+		// `UInt64.max` exceeds `Int64.max`, so it can't round-trip as `.int(_)`.
+		#expect(AttributeValue(UInt64.max) == .string("\(UInt64.max)"))
+		// `Int128.max` (when available on the target) is also out of range.
+		if #available(iOS 18.0, macOS 15.0, *) {
+			#expect(AttributeValue(Int128.max) == .string("\(Int128.max)"))
+		}
+		// Values that DO fit still go through `.int(...)`.
+		#expect(AttributeValue(UInt64(Int64.max)) == .int(Int64.max))
+	}
+
 	@Test
 	func payloadAccessorsExtractValues() {
 		#expect(AttributeValue.string("x").stringValue == "x")

--- a/Tests/NautilusTelemetryTests/Utilities/AttributeValueTests.swift
+++ b/Tests/NautilusTelemetryTests/Utilities/AttributeValueTests.swift
@@ -1,0 +1,104 @@
+// Created by Ladd Van Tol on 2026-05-01.
+// Copyright © 2026 Airbnb Inc. All rights reserved.
+
+import Foundation
+import Testing
+
+@testable import NautilusTelemetry
+
+/// Compile-time Sendable check: this function would not compile if `T` weren't `Sendable`.
+private func requireSendable(_: (some Sendable).Type) { }
+
+// MARK: - AttributeValueTests
+
+@Suite
+struct AttributeValueTests {
+
+	@Test
+	func attributeValueIsSendable() {
+		requireSendable(AttributeValue.self)
+		requireSendable(TelemetryAttributes.self)
+	}
+
+	@Test
+	func literalConstruction() {
+		let string: AttributeValue = "hello"
+		#expect(string == .string("hello"))
+
+		let int: AttributeValue = 42
+		#expect(int == .int(42))
+
+		let double: AttributeValue = 3.14
+		#expect(double == .double(3.14))
+
+		let bool: AttributeValue = true
+		#expect(bool == .bool(true))
+
+		let array: AttributeValue = ["a", 1, true]
+		#expect(array == .array([.string("a"), .int(1), .bool(true)]))
+
+		let dict: AttributeValue = ["a": 1, "b": "two"]
+		if case .keyValueList(let v) = dict {
+			#expect(v["a"] == .int(1))
+			#expect(v["b"] == .string("two"))
+		} else {
+			Issue.record("expected keyValueList")
+		}
+	}
+
+	@Test
+	func integerInitializerNormalizesToInt64() {
+		#expect(AttributeValue(Int32(7)) == .int(7))
+		#expect(AttributeValue(UInt8(7)) == .int(7))
+		#expect(AttributeValue(Int64(-1)) == .int(-1))
+	}
+
+	@Test
+	func payloadAccessorsExtractValues() {
+		#expect(AttributeValue.string("x").stringValue == "x")
+		#expect(AttributeValue.int(5).intValue == 5)
+		#expect(AttributeValue.double(2.5).doubleValue == 2.5)
+		#expect(AttributeValue.bool(false).boolValue == false)
+
+		// Type-mismatched accessors return nil rather than crashing.
+		#expect(AttributeValue.string("x").intValue == nil)
+		#expect(AttributeValue.int(5).stringValue == nil)
+	}
+
+	/// Deprecated conversion from a `[String: String]` to `TelemetryAttributes`.
+	@Test
+	@available(*, deprecated)
+	func deprecatedStringDictionaryConversion() {
+		let source: [String: String] = ["a": "1", "b": "2"]
+		let attributes = source.asTelemetryAttributes
+		#expect(attributes["a"] == .string("1"))
+		#expect(attributes["b"] == .string("2"))
+	}
+
+	@Test
+	func groupedBuilderConstructsMixedTypeAttributes() {
+		let userId = "abc123"
+		let retryAttempt = 2
+		let isRetry = true
+
+		let attributes = TelemetryAttributes(
+			string: ["user.id": userId],
+			int: ["retry.attempt": retryAttempt],
+			bool: ["http.is_retry": isRetry]
+		)
+
+		#expect(attributes["user.id"] == .string("abc123"))
+		#expect(attributes["retry.attempt"] == .int(2))
+		#expect(attributes["http.is_retry"] == .bool(true))
+	}
+
+	@Test
+	func groupedBuilderLaterKeysOverwriteEarlier() {
+		// Per doc comment: last-write-wins across groups.
+		let attributes = TelemetryAttributes(
+			string: ["key": "from-string"],
+			int: ["key": 42]
+		)
+		#expect(attributes["key"] == .int(42))
+	}
+}

--- a/Tests/NautilusTelemetryTests/Utilities/ResourceAttributesTests.swift
+++ b/Tests/NautilusTelemetryTests/Utilities/ResourceAttributesTests.swift
@@ -19,15 +19,15 @@ final class ResourceAttributesTests: XCTestCase {
 
 		_ = try XCTUnwrap(exporter.convertToOTLP(attributes: attributes)) // make sure it converts
 
-		let serviceName = try XCTUnwrap(attributes["service.name"] as? String)
+		let serviceName = try XCTUnwrap(attributes["service.name"]?.stringValue)
 		_ = try XCTUnwrap(attributes["service.version"])
 		_ = try XCTUnwrap(attributes["telemetry.sdk.name"])
 		_ = try XCTUnwrap(attributes["telemetry.sdk.language"])
 		_ = try XCTUnwrap(attributes["device.id"])
 		_ = try XCTUnwrap(attributes["foo"])
 		_ = try XCTUnwrap(attributes["os.type"])
-		let osName = try XCTUnwrap(attributes["os.name"] as? String)
-		let osVersion = try XCTUnwrap(attributes["os.version"] as? String)
+		let osName = try XCTUnwrap(attributes["os.name"]?.stringValue)
+		let osVersion = try XCTUnwrap(attributes["os.version"]?.stringValue)
 
 		// Verify platform-specific OS name
 		#if os(macOS)
@@ -79,7 +79,7 @@ final class ResourceAttributesTests: XCTestCase {
 
 		// Even with empty options, additionalAttributes should be included
 		let filtered = resourceAttributes.keyValues(options: [])
-		XCTAssertEqual(filtered["custom.key"] as? String, "value")
+		XCTAssertEqual(filtered["custom.key"], "value")
 		XCTAssertNil(filtered["service.name"])
 	}
 }


### PR DESCRIPTION
- Eliminate `AnyHashable` in attributes, allowing attributes to be `Sendable`. This breaks backwards compatibility, as we can't reproduce all the implicit conversions that `AnyHashable` supports. In particular:

`attributes["os.type"] = osType`
becomes
`attributes["os.type"] = .string(osType)`

And associated changes to dictionaries of attributes.

- Convert `lock.withLockUnchecked` to `lock.withLock` for sendable cases.
- Fix bug where "maxBuckets" was not copied on `snapshotAndReset`
- Support mapping Int128 attributes to string, tweak FixedWidthInteger code.
- Helpers and performance tests.

@jparise 
@bachand
