### PR TITLE
Sanity check network timing

### DIFF
--- a/Sources/NautilusTelemetry/Tracing/Baggage.swift
+++ b/Sources/NautilusTelemetry/Tracing/Baggage.swift
@@ -10,7 +10,7 @@ import os
 
 // MARK: - SubtraceLinking
 
-public struct SubtraceLinking: OptionSet {
+public struct SubtraceLinking: OptionSet, Sendable {
 
 	public init(rawValue: Int) {
 		self.rawValue = rawValue
@@ -27,7 +27,7 @@ public struct SubtraceLinking: OptionSet {
 
 // MARK: - Baggage
 
-public final class Baggage: TelemetryAttributesContainer, @unchecked Sendable {
+public final class Baggage: TelemetryAttributesContainer, Sendable {
 
 	// MARK: Lifecycle
 

--- a/Sources/NautilusTelemetry/Tracing/Span+URLSession.swift
+++ b/Sources/NautilusTelemetry/Tracing/Span+URLSession.swift
@@ -300,6 +300,7 @@ extension Span {
 	func elapsedNanoseconds(_ start: Date?, _ end: Date?, upperBound: Duration) -> Int64? {
 		guard let start, let end else { return nil }
 		let duration = end.timeIntervalSince(start)
+		guard duration >= 0, duration < (Double(Int64.max) / 1_000_000_000.0) else { return nil }
 		let result = Int64(duration * 1_000_000_000)
 		guard result >= 0, result < upperBound.asNanoseconds else { return nil }
 		return result

--- a/Sources/NautilusTelemetry/Tracing/Span+URLSession.swift
+++ b/Sources/NautilusTelemetry/Tracing/Span+URLSession.swift
@@ -104,22 +104,32 @@ extension Span {
 		addAttribute("http.connection.reused", metric.isReusedConnection)
 		addAttribute("http.connection.proxied", metric.isProxyConnection)
 
+		// Plausible upper bound on timing,
+		let upperBound = startTime.duration(to: ContinuousClock.now)
+
 		// Connection sub-phase timings could also be expressed as sub-spans of the HTTP span, but that's less
 		// convenient for analytics.
 		// Will be omitted if the timestamps are nil, or express a negative duration.
-		addAttribute("http.dns.duration", elapsedNanoseconds(metric.domainLookupStartDate, metric.domainLookupEndDate))
+		addAttribute(
+			"http.dns.duration",
+			elapsedNanoseconds(metric.domainLookupStartDate, metric.domainLookupEndDate, upperBound: upperBound)
+		)
 		if
-			let connectDuration = elapsedNanoseconds(metric.connectStartDate, metric.connectEndDate),
-			let tlsDuration = elapsedNanoseconds(metric.secureConnectionStartDate, metric.secureConnectionEndDate)
+			let connectDuration = elapsedNanoseconds(metric.connectStartDate, metric.connectEndDate, upperBound: upperBound),
+			let tlsDuration = elapsedNanoseconds(metric.secureConnectionStartDate, metric.secureConnectionEndDate, upperBound: upperBound)
 		{
-			if connectDuration > tlsDuration {
-				addAttribute("http.tcp.duration", connectDuration - tlsDuration)
+			let elapsedNanoseconds = connectDuration - tlsDuration
+			if elapsedNanoseconds > 0, elapsedNanoseconds < upperBound.asNanoseconds {
+				addAttribute("http.tcp.duration", elapsedNanoseconds)
 			}
 
 			addAttribute("http.tls.duration", tlsDuration)
 		}
 
-		addAttribute("http.first_byte.duration", elapsedNanoseconds(metric.fetchStartDate, metric.responseStartDate))
+		addAttribute(
+			"http.first_byte.duration",
+			elapsedNanoseconds(metric.fetchStartDate, metric.responseStartDate, upperBound: upperBound)
+		)
 	}
 
 	/// Annotates the span with attributes from the task and its URLRequest.
@@ -287,11 +297,12 @@ extension Span {
 		}
 	}
 
-	func elapsedNanoseconds(_ start: Date?, _ end: Date?) -> Int64? {
+	func elapsedNanoseconds(_ start: Date?, _ end: Date?, upperBound: Duration) -> Int64? {
 		guard let start, let end else { return nil }
 		let duration = end.timeIntervalSince(start)
-		guard duration >= 0 else { return nil }
-		return Int64(duration * 1_000_000_000)
+		let result = Int64(duration * 1_000_000_000)
+		guard result >= 0, result < upperBound.asNanoseconds else { return nil }
+		return result
 	}
 
 	/// Add URLRequest attributes to the span

--- a/Tests/NautilusTelemetryTests/Tracing/Span+URLSessionTests.swift
+++ b/Tests/NautilusTelemetryTests/Tracing/Span+URLSessionTests.swift
@@ -6,6 +6,8 @@ import XCTest
 
 @testable import NautilusTelemetry
 
+// MARK: - SpanURLSessionTests
+
 final class SpanURLSessionTests: XCTestCase {
 
 	let tracer = Tracer()
@@ -113,16 +115,23 @@ final class SpanURLSessionTests: XCTestCase {
 		let span = tracer.startSpan(name: #function)
 		let now = Date()
 
-		span.addAttribute("duration_nils", span.elapsedNanoseconds(nil, nil))
-		span.addAttribute("duration_start_in_future", span.elapsedNanoseconds(NSDate.distantFuture, NSDate.distantPast))
-		span.addAttribute("duration_zero", span.elapsedNanoseconds(now, now))
-		span.addAttribute("duration_one_second", span.elapsedNanoseconds(now, now + 1.0))
+		let upperBound = Duration.seconds(1000)
+
+		span.addAttribute("duration_nils", span.elapsedNanoseconds(nil, nil, upperBound: upperBound))
+		span.addAttribute(
+			"duration_start_in_future",
+			span.elapsedNanoseconds(NSDate.distantFuture, NSDate.distantPast, upperBound: upperBound)
+		)
+		span.addAttribute("duration_zero", span.elapsedNanoseconds(now, now, upperBound: upperBound))
+		span.addAttribute("duration_one_second", span.elapsedNanoseconds(now, now + 1.0, upperBound: upperBound))
+		span.addAttribute("duration_two_thousand_seconds", span.elapsedNanoseconds(now, now + 2000.0, upperBound: upperBound))
 
 		let attributes = try XCTUnwrap(span.attributes)
 		XCTAssertNil(attributes["duration_nils"])
 		XCTAssertNil(attributes["duration_start_in_future"])
 		XCTAssertEqual(attributes["duration_zero"], 0)
 		XCTAssertEqual(attributes["duration_one_second"], 1_000_000_000)
+		XCTAssertNil(attributes["duration_two_thousand_seconds"]) // exceeds upper bound
 	}
 
 	func testUrlSchemeAttributeCaptured() throws {
@@ -187,5 +196,59 @@ final class SpanURLSessionTests: XCTestCase {
 		let attributes = try XCTUnwrap(span.attributes)
 		XCTAssertEqual(attributes["http.priority"], .double(Double(task.priority)))
 	}
+
+	func testAddMetricsLive() async throws {
+		guard TestUtils.testEnabled("liveNetworkTests") else { return }
+
+		let url = try XCTUnwrap(URL(string: "https://api.airbnb.com/v2/ping"))
+		let span = tracer.startSpan(name: #function)
+
+		let delegate = MetricsCapturingDelegate()
+		let session = URLSession(configuration: .default, delegate: delegate, delegateQueue: nil)
+		let _ = try await session.data(from: url)
+		let metrics = try XCTUnwrap(delegate.capturedMetrics)
+
+		span.addMetrics(metrics)
+
+		let attributes = try XCTUnwrap(span.attributes)
+
+		// Byte counts
+		XCTAssertNotNil(attributes["http.response.size"])
+		XCTAssertNotNil(attributes["http.response.body.size"])
+
+		// Network attributes always populated for a successful request
+		XCTAssertNotNil(attributes["network.peer.address"])
+		XCTAssertNotNil(attributes["network.type"])
+		XCTAssertNotNil(attributes["network.protocol.version"])
+
+		// TLS — api.airbnb.com speaks HTTPS
+		XCTAssertNotNil(attributes["tls.protocol.version"])
+		XCTAssertNotNil(attributes["tls.cipher"])
+
+		// Timing: first-byte duration must be a positive nanosecond count
+		let firstByte = try XCTUnwrap(attributes["http.first_byte.duration"]?.intPayload)
+		XCTAssertGreaterThan(firstByte, 0)
+	}
+
+}
+
+// MARK: - MetricsCapturingDelegate
+
+private final class MetricsCapturingDelegate: NSObject, URLSessionTaskDelegate, @unchecked Sendable {
+
+	// MARK: Internal
+
+	var capturedMetrics: URLSessionTaskMetrics? {
+		lock.withLock { metrics }
+	}
+
+	func urlSession(_: URLSession, task _: URLSessionTask, didFinishCollecting metrics: URLSessionTaskMetrics) {
+		lock.withLock { self.metrics = metrics }
+	}
+
+	// MARK: Private
+
+	private var metrics: URLSessionTaskMetrics?
+	private let lock = NSLock()
 
 }

--- a/Tests/NautilusTelemetryTests/Tracing/Span+URLSessionTests.swift
+++ b/Tests/NautilusTelemetryTests/Tracing/Span+URLSessionTests.swift
@@ -2,6 +2,7 @@
 // Copyright © 2025 Airbnb Inc. All rights reserved.
 
 import Foundation
+import Synchronization
 import XCTest
 
 @testable import NautilusTelemetry
@@ -234,21 +235,16 @@ final class SpanURLSessionTests: XCTestCase {
 
 // MARK: - MetricsCapturingDelegate
 
-private final class MetricsCapturingDelegate: NSObject, URLSessionTaskDelegate, @unchecked Sendable {
-
-	// MARK: Internal
+private final class MetricsCapturingDelegate: NSObject, URLSessionTaskDelegate, Sendable {
 
 	var capturedMetrics: URLSessionTaskMetrics? {
-		lock.withLock { metrics }
+		mutex.withLock { $0 }
 	}
 
 	func urlSession(_: URLSession, task _: URLSessionTask, didFinishCollecting metrics: URLSessionTaskMetrics) {
-		lock.withLock { self.metrics = metrics }
+		mutex.withLock { $0 = metrics }
 	}
 
-	// MARK: Private
-
-	private var metrics: URLSessionTaskMetrics?
-	private let lock = NSLock()
+	private let mutex: Mutex<URLSessionTaskMetrics?> = Mutex(nil)
 
 }


### PR DESCRIPTION
- Add a sanity check to URLSession timing metrics reported from Apple. I don't have a repro, but seeing rare cases where our trace shows DNS timings suspiciously close to 2^32 milliseconds. (but not exactly). 
- Sendable annotations
- Add an optional (environment variable driven) live test to exercise URLSession metric processing.

<img width="398" height="34" alt="Screenshot 2026-05-20 at 4 02 54 PM" src="https://github.com/user-attachments/assets/a46bf190-6251-47b4-8778-57e23093b5b2" />

@jparise 
@bachand