### PR TITLE
Replace OSAllocatedUnfairLock with Mutex

### DIFF
--- a/Sources/NautilusTelemetry/Metrics/Counter.swift
+++ b/Sources/NautilusTelemetry/Metrics/Counter.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-import os
+import Synchronization
 
 public class Counter<T: MetricNumeric>: Instrument, ExportableInstrument {
 
@@ -29,7 +29,7 @@ public class Counter<T: MetricNumeric>: Instrument, ExportableInstrument {
 
 	public var isMonotonic: Bool { true }
 
-	public var isEmpty: Bool { lock.withLock { values.isEmpty } }
+	public var isEmpty: Bool { lockedValues.withLock { $0.isEmpty } }
 
 	public func add(_ number: T, attributes: TelemetryAttributes = [:]) {
 		if isMonotonic, number < 0 {
@@ -37,20 +37,20 @@ public class Counter<T: MetricNumeric>: Instrument, ExportableInstrument {
 			assert(false, "monotonic counters can only be increased")
 			return
 		}
-		lock.withLock {
-			values.add(number, attributes: attributes)
+		lockedValues.withLock {
+			$0.add(number, attributes: attributes)
 		}
 	}
 
 	public func snapshotAndReset() -> Instrument {
 		let now = ContinuousClock.now
 
-		return lock.withLock {
+		return lockedValues.withLock { values in
 			let copy = Self(name: name, unit: unit, description: description)
 			copy.startTime = startTime
 			copy.endTime = now
 			copy.aggregationTemporality = aggregationTemporality
-			copy.values = values.snapshotAndReset()
+			copy.lockedValues.withLock { $0 = values.snapshotAndReset() }
 
 			// now reset
 			startTime = now
@@ -62,7 +62,8 @@ public class Counter<T: MetricNumeric>: Instrument, ExportableInstrument {
 
 	// MARK: Internal
 
-	var values = MetricValues<T>()
+	/// Thread-safe snapshot of the recorded values.
+	var values: MetricValues<T> { lockedValues.withLock { $0 } }
 
 	func exportOTLP(_ exporter: Exporter) -> OTLP.V1Metric {
 		exporter.exportOTLP(counter: self)
@@ -72,5 +73,5 @@ public class Counter<T: MetricNumeric>: Instrument, ExportableInstrument {
 
 	/// Locking is handled at the Instrument level
 	/// The implementation must take care to avoid concurrently modifying values
-	private let lock = OSAllocatedUnfairLock()
+	private let lockedValues = Mutex(MetricValues<T>())
 }

--- a/Sources/NautilusTelemetry/Metrics/ExponentialHistogram.swift
+++ b/Sources/NautilusTelemetry/Metrics/ExponentialHistogram.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-import os
+import Synchronization
 
 /// An exponential histogram where bucket boundaries are `base^i` with `base = 2^(2^-scale)`.
 /// https://opentelemetry.io/docs/specs/otel/metrics/data-model/#exponentialhistogram
@@ -32,7 +32,7 @@ public class ExponentialHistogram<T: MetricNumeric>: Instrument, ExportableInstr
 		self.unit = unit
 		self.description = description
 		self.maxBuckets = maxBuckets
-		values = ExponentialHistogramValues<T>()
+		lockedValues = Mutex(ExponentialHistogramValues<T>())
 	}
 
 	// MARK: Public
@@ -45,25 +45,25 @@ public class ExponentialHistogram<T: MetricNumeric>: Instrument, ExportableInstr
 	public private(set) var endTime: ContinuousClock.Instant? = nil
 	public var aggregationTemporality = AggregationTemporality.delta
 
-	public var isEmpty: Bool { lock.withLock { values.isEmpty } }
+	public var isEmpty: Bool { lockedValues.withLock { $0.isEmpty } }
 
 	/// Record a value. Positive, negative, and zero values are all allowed (unlike `Histogram`),
 	/// since the spec maps them into separate positive/negative/zero buckets.
 	public func record(_ number: T, attributes: TelemetryAttributes = [:]) {
-		lock.withLock {
-			values.record(number, attributes: attributes)
+		lockedValues.withLock {
+			$0.record(number, attributes: attributes)
 		}
 	}
 
 	public func snapshotAndReset() -> Instrument {
 		let now = ContinuousClock.now
 
-		return lock.withLock {
+		return lockedValues.withLock { values in
 			let copy = Self(name: name, unit: unit, description: description, maxBuckets: maxBuckets)
 			copy.startTime = startTime
 			copy.endTime = now
 			copy.aggregationTemporality = aggregationTemporality
-			copy.values = values.snapshotAndReset()
+			copy.lockedValues.withLock { $0 = values.snapshotAndReset() }
 
 			// now reset the instrument
 			startTime = now
@@ -75,7 +75,8 @@ public class ExponentialHistogram<T: MetricNumeric>: Instrument, ExportableInstr
 
 	// MARK: Internal
 
-	var values: ExponentialHistogramValues<T>
+	/// Thread-safe snapshot of the recorded values.
+	var values: ExponentialHistogramValues<T> { lockedValues.withLock { $0 } }
 
 	func exportOTLP(_ exporter: Exporter) -> OTLP.V1Metric {
 		exporter.exportOTLP(histogram: self)
@@ -85,5 +86,5 @@ public class ExponentialHistogram<T: MetricNumeric>: Instrument, ExportableInstr
 
 	/// Locking is handled at the Instrument level
 	/// The implementation must take care to avoid concurrently modifying values
-	private let lock = OSAllocatedUnfairLock()
+	private let lockedValues: Mutex<ExponentialHistogramValues<T>>
 }

--- a/Sources/NautilusTelemetry/Metrics/Histogram.swift
+++ b/Sources/NautilusTelemetry/Metrics/Histogram.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-import os
+import Synchronization
 
 public class Histogram<T: MetricNumeric>: Instrument, ExportableInstrument {
 
@@ -22,7 +22,7 @@ public class Histogram<T: MetricNumeric>: Instrument, ExportableInstrument {
 		self.name = name
 		self.unit = unit
 		self.description = description
-		values = HistogramValues<T>(explicitBounds: explicitBounds)
+		lockedValues = Mutex(HistogramValues<T>(explicitBounds: explicitBounds))
 	}
 
 	// MARK: Public
@@ -34,7 +34,7 @@ public class Histogram<T: MetricNumeric>: Instrument, ExportableInstrument {
 	public private(set) var endTime: ContinuousClock.Instant? = nil
 	public var aggregationTemporality = AggregationTemporality.delta
 
-	public var isEmpty: Bool { lock.withLock { values.isEmpty } }
+	public var isEmpty: Bool { lockedValues.withLock { $0.isEmpty } }
 
 	public func record(_ number: T, attributes: TelemetryAttributes = [:]) {
 		if number < 0 {
@@ -42,20 +42,20 @@ public class Histogram<T: MetricNumeric>: Instrument, ExportableInstrument {
 			return
 		}
 
-		lock.withLock {
-			values.record(number, attributes: attributes)
+		lockedValues.withLock {
+			$0.record(number, attributes: attributes)
 		}
 	}
 
 	public func snapshotAndReset() -> Instrument {
 		let now = ContinuousClock.now
 
-		return lock.withLock {
+		return lockedValues.withLock { values in
 			let copy = Self(name: name, unit: unit, description: description, explicitBounds: values.explicitBounds)
 			copy.startTime = startTime
 			copy.endTime = now
 			copy.aggregationTemporality = aggregationTemporality
-			copy.values = values.snapshotAndReset()
+			copy.lockedValues.withLock { $0 = values.snapshotAndReset() }
 
 			// now reset the instrument
 			startTime = now
@@ -67,7 +67,8 @@ public class Histogram<T: MetricNumeric>: Instrument, ExportableInstrument {
 
 	// MARK: Internal
 
-	var values: HistogramValues<T>
+	/// Thread-safe snapshot of the recorded values.
+	var values: HistogramValues<T> { lockedValues.withLock { $0 } }
 
 	func exportOTLP(_ exporter: Exporter) -> OTLP.V1Metric {
 		exporter.exportOTLP(histogram: self)
@@ -77,5 +78,5 @@ public class Histogram<T: MetricNumeric>: Instrument, ExportableInstrument {
 
 	/// Locking is handled at the Instrument level
 	/// The implementation must take care to avoid concurrently modifying values
-	private let lock = OSAllocatedUnfairLock()
+	private let lockedValues: Mutex<HistogramValues<T>>
 }

--- a/Sources/NautilusTelemetry/Metrics/Meter.swift
+++ b/Sources/NautilusTelemetry/Metrics/Meter.swift
@@ -107,9 +107,6 @@ public final class Meter {
 	/// Optional to avoid initialization order issue
 	var flushTimer: FlushTimer?
 
-	/// Used for protecting internal state
-	let activeInstruments = Mutex<[Instrument]>([])
-
 	/// Sets the flush interval for reporting back to the configured ``Reporter``.
 	var flushInterval: TimeInterval {
 		didSet {
@@ -140,5 +137,10 @@ public final class Meter {
 			reporter.reportInstruments(instrumentsToReport)
 		}
 	}
+
+	// MARK: Private
+
+	/// Used for protecting internal state
+	private let activeInstruments = Mutex<[Instrument]>([])
 
 }

--- a/Sources/NautilusTelemetry/Metrics/Meter.swift
+++ b/Sources/NautilusTelemetry/Metrics/Meter.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-import os
+import Synchronization
 
 // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/api.md
 // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/datamodel.md
@@ -107,7 +107,8 @@ public final class Meter {
 	/// Optional to avoid initialization order issue
 	var flushTimer: FlushTimer?
 
-	var activeInstruments = [Instrument]()
+	/// Used for protecting internal state
+	let activeInstruments = Mutex<[Instrument]>([])
 
 	/// Sets the flush interval for reporting back to the configured ``Reporter``.
 	var flushInterval: TimeInterval {
@@ -117,32 +118,27 @@ public final class Meter {
 	}
 
 	func register(_ instrument: Instrument) {
-		lock.withLock {
-			activeInstruments.append(instrument)
+		activeInstruments.withLock {
+			$0.append(instrument)
 		}
 	}
 
 	func unregister(_ instrument: Instrument) {
-		lock.withLock {
+		activeInstruments.withLock {
 			// O(N) -- may need to improve this
-			activeInstruments.removeAll { $0 === instrument }
+			$0.removeAll { $0 === instrument }
 		}
 	}
 
 	func flushActiveInstruments() {
-		let instrumentsToReport = lock.withLock {
+		let instrumentsToReport = activeInstruments.withLock {
 			// Make copies
-			activeInstruments.compactMap { $0.snapshotAndReset() }
+			$0.compactMap { $0.snapshotAndReset() }
 		}
 
 		if instrumentsToReport.count > 0, let reporter = InstrumentationSystem.reporter {
 			reporter.reportInstruments(instrumentsToReport)
 		}
 	}
-
-	// MARK: Private
-
-	/// Used for protecting internal state
-	private let lock = OSAllocatedUnfairLock()
 
 }

--- a/Sources/NautilusTelemetry/Metrics/ObservableCounter.swift
+++ b/Sources/NautilusTelemetry/Metrics/ObservableCounter.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-import os
+import Synchronization
 
 public class ObservableCounter<T: MetricNumeric>: Instrument, ExportableInstrument {
 
@@ -30,12 +30,12 @@ public class ObservableCounter<T: MetricNumeric>: Instrument, ExportableInstrume
 
 	public var isMonotonic: Bool { true }
 
-	public var isEmpty: Bool { lock.withLock { values.isEmpty } }
+	public var isEmpty: Bool { lockedValues.withLock { $0.isEmpty } }
 
 	/// https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/api.md#asynchronous-counter-creation
 	public func observe(_ number: T, attributes: TelemetryAttributes = [:]) {
-		lock.withLock {
-			values.set(number, attributes: attributes)
+		lockedValues.withLock {
+			$0.set(number, attributes: attributes)
 		}
 	}
 
@@ -43,12 +43,12 @@ public class ObservableCounter<T: MetricNumeric>: Instrument, ExportableInstrume
 		let now = ContinuousClock.now
 		callback(self)
 
-		return lock.withLock {
+		return lockedValues.withLock { values in
 			let copy = Self(name: name, unit: unit, description: description, callback: callback)
 			copy.startTime = startTime
 			copy.endTime = now
 			copy.aggregationTemporality = aggregationTemporality
-			copy.values = values.snapshotAndReset()
+			copy.lockedValues.withLock { $0 = values.snapshotAndReset() }
 
 			// now reset
 			startTime = now
@@ -61,7 +61,9 @@ public class ObservableCounter<T: MetricNumeric>: Instrument, ExportableInstrume
 	// MARK: Internal
 
 	let callback: (ObservableCounter<T>) -> Void
-	var values = MetricValues<T>()
+
+	/// Thread-safe snapshot of the recorded values.
+	var values: MetricValues<T> { lockedValues.withLock { $0 } }
 
 	func exportOTLP(_ exporter: Exporter) -> OTLP.V1Metric {
 		exporter.exportOTLP(counter: self)
@@ -71,5 +73,5 @@ public class ObservableCounter<T: MetricNumeric>: Instrument, ExportableInstrume
 
 	/// Locking is handled at the Instrument level
 	/// The implementation must take care to avoid concurrently modifying values
-	private let lock = OSAllocatedUnfairLock()
+	private let lockedValues = Mutex(MetricValues<T>())
 }

--- a/Sources/NautilusTelemetry/Metrics/ObservableGauge.swift
+++ b/Sources/NautilusTelemetry/Metrics/ObservableGauge.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-import os
+import Synchronization
 
 public class ObservableGauge<T: MetricNumeric>: Instrument, ExportableInstrument {
 
@@ -31,8 +31,8 @@ public class ObservableGauge<T: MetricNumeric>: Instrument, ExportableInstrument
 	public var isEmpty: Bool { false }
 
 	public func observe(_ number: T, attributes: TelemetryAttributes = [:]) {
-		lock.withLock {
-			values.set(number, attributes: attributes)
+		lockedValues.withLock {
+			$0.set(number, attributes: attributes)
 		}
 	}
 
@@ -40,11 +40,11 @@ public class ObservableGauge<T: MetricNumeric>: Instrument, ExportableInstrument
 		let now = ContinuousClock.now
 		callback(self)
 
-		return lock.withLock {
+		return lockedValues.withLock { values in
 			let copy = Self(name: name, unit: unit, description: description, callback: callback)
 			copy.startTime = startTime
 			copy.endTime = now
-			copy.values = values.snapshotAndReset()
+			copy.lockedValues.withLock { $0 = values.snapshotAndReset() }
 
 			// now reset
 			startTime = now
@@ -57,7 +57,9 @@ public class ObservableGauge<T: MetricNumeric>: Instrument, ExportableInstrument
 	// MARK: Internal
 
 	let callback: (ObservableGauge<T>) -> Void
-	var values = MetricValues<T>()
+
+	/// Thread-safe snapshot of the recorded values.
+	var values: MetricValues<T> { lockedValues.withLock { $0 } }
 
 	func exportOTLP(_ exporter: Exporter) -> OTLP.V1Metric {
 		exporter.exportOTLP(gauge: self)
@@ -66,5 +68,5 @@ public class ObservableGauge<T: MetricNumeric>: Instrument, ExportableInstrument
 	// MARK: Private
 
 	/// Locking is handled at the Instrument level
-	private let lock = OSAllocatedUnfairLock()
+	private let lockedValues = Mutex(MetricValues<T>())
 }

--- a/Sources/NautilusTelemetry/Metrics/ObservableUpDownCounter.swift
+++ b/Sources/NautilusTelemetry/Metrics/ObservableUpDownCounter.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-import os
+import Synchronization
 
 public class ObservableUpDownCounter<T: MetricNumeric>: Instrument, ExportableInstrument {
 
@@ -30,11 +30,11 @@ public class ObservableUpDownCounter<T: MetricNumeric>: Instrument, ExportableIn
 
 	public var isMonotonic: Bool { false }
 
-	public var isEmpty: Bool { lock.withLock { values.isEmpty } }
+	public var isEmpty: Bool { lockedValues.withLock { $0.isEmpty } }
 
 	public func observe(_ number: T, attributes: TelemetryAttributes = [:]) {
-		lock.withLock {
-			values.set(number, attributes: attributes)
+		lockedValues.withLock {
+			$0.set(number, attributes: attributes)
 		}
 	}
 
@@ -42,11 +42,11 @@ public class ObservableUpDownCounter<T: MetricNumeric>: Instrument, ExportableIn
 		let now = ContinuousClock.now
 		callback(self)
 
-		return lock.withLock {
+		return lockedValues.withLock { values in
 			let copy = Self(name: name, unit: unit, description: description, callback: callback)
 			copy.startTime = startTime
 			copy.endTime = now
-			copy.values = values.snapshotAndReset()
+			copy.lockedValues.withLock { $0 = values.snapshotAndReset() }
 
 			// now reset
 			startTime = now
@@ -59,7 +59,9 @@ public class ObservableUpDownCounter<T: MetricNumeric>: Instrument, ExportableIn
 	// MARK: Internal
 
 	let callback: (ObservableUpDownCounter<T>) -> Void
-	var values = MetricValues<T>()
+
+	/// Thread-safe snapshot of the recorded values.
+	var values: MetricValues<T> { lockedValues.withLock { $0 } }
 
 	func exportOTLP(_ exporter: Exporter) -> OTLP.V1Metric {
 		exporter.exportOTLP(counter: self)
@@ -68,5 +70,5 @@ public class ObservableUpDownCounter<T: MetricNumeric>: Instrument, ExportableIn
 	// MARK: Private
 
 	/// Locking is handled at the Instrument level
-	private let lock = OSAllocatedUnfairLock()
+	private let lockedValues = Mutex(MetricValues<T>())
 }

--- a/Sources/NautilusTelemetry/Tracing/Baggage.swift
+++ b/Sources/NautilusTelemetry/Tracing/Baggage.swift
@@ -47,10 +47,18 @@ public final class Baggage: TelemetryAttributesContainer, Sendable {
 		self.subTraceId = subTraceId
 		self.subtraceLinking = subtraceLinking
 		// Infer baggage attributes from current context if not provided
-		_attributes = Mutex(attributes ?? Baggage.currentBaggageTaskLocal?.attributes)
+		lockedAttributes = Mutex(attributes ?? Baggage.currentBaggageTaskLocal?.attributes)
 	}
 
 	// MARK: Public
+
+	/// The parent span this baggage is attached to.
+	public let span: Span
+
+	/// Vend private attributes as a thread-safe copy
+	public var attributes: TelemetryAttributes? {
+		lockedAttributes.withLock { $0 }
+	}
 
 	/// Adds an attribute to the baggage. This can be used to propagate selected attributes to child spans.
 	/// https://opentelemetry.io/docs/concepts/signals/baggage/#baggage-is-not-the-same-as-attributes
@@ -60,7 +68,7 @@ public final class Baggage: TelemetryAttributesContainer, Sendable {
 	public func addAttribute(_ name: String, _ value: AttributeValue?) {
 		guard let value else { return }
 
-		_attributes.withLock { attributes in
+		lockedAttributes.withLock { attributes in
 			if attributes == nil {
 				attributes = TelemetryAttributes()
 			}
@@ -71,19 +79,11 @@ public final class Baggage: TelemetryAttributesContainer, Sendable {
 
 	public subscript(name: String) -> AttributeValue? {
 		get {
-			_attributes.withLock { $0?[name] }
+			lockedAttributes.withLock { $0?[name] }
 		}
 		set(newValue) {
 			addAttribute(name, newValue)
 		}
-	}
-
-	/// The parent span this baggage is attached to.
-	public let span: Span
-
-	/// Vend private attributes as a thread-safe copy
-	public var attributes: TelemetryAttributes? {
-		_attributes.withLock { $0 }
 	}
 
 	// MARK: Internal
@@ -97,6 +97,6 @@ public final class Baggage: TelemetryAttributesContainer, Sendable {
 	// MARK: Private
 
 	/// Carry arbitrary attributes, guarded for thread-safe access:
-	private let _attributes: Mutex<TelemetryAttributes?>
+	private let lockedAttributes: Mutex<TelemetryAttributes?>
 
 }

--- a/Sources/NautilusTelemetry/Tracing/Baggage.swift
+++ b/Sources/NautilusTelemetry/Tracing/Baggage.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-import os
+import Synchronization
 
 // MARK: - SubtraceLinking
 
@@ -47,7 +47,7 @@ public final class Baggage: TelemetryAttributesContainer, Sendable {
 		self.subTraceId = subTraceId
 		self.subtraceLinking = subtraceLinking
 		// Infer baggage attributes from current context if not provided
-		_attributes = attributes ?? Baggage.currentBaggageTaskLocal?.attributes
+		_attributes = Mutex(attributes ?? Baggage.currentBaggageTaskLocal?.attributes)
 	}
 
 	// MARK: Public
@@ -60,24 +60,30 @@ public final class Baggage: TelemetryAttributesContainer, Sendable {
 	public func addAttribute(_ name: String, _ value: AttributeValue?) {
 		guard let value else { return }
 
-		lock.withLock {
-			if _attributes == nil {
-				_attributes = TelemetryAttributes()
+		_attributes.withLock { attributes in
+			if attributes == nil {
+				attributes = TelemetryAttributes()
 			}
 
-			_attributes?[name] = value
+			attributes?[name] = value
 		}
 	}
 
 	public subscript(name: String) -> AttributeValue? {
 		get {
-			lock.withLock {
-				_attributes?[name]
-			}
+			_attributes.withLock { $0?[name] }
 		}
 		set(newValue) {
 			addAttribute(name, newValue)
 		}
+	}
+
+	/// The parent span this baggage is attached to.
+	public let span: Span
+
+	/// Vend private attributes as a thread-safe copy
+	public var attributes: TelemetryAttributes? {
+		_attributes.withLock { $0 }
 	}
 
 	// MARK: Internal
@@ -85,20 +91,12 @@ public final class Baggage: TelemetryAttributesContainer, Sendable {
 	/// TaskLocal works even for conventional threads: https://developer.apple.com/documentation/swift/tasklocal
 	@TaskLocal static var currentBaggageTaskLocal: Baggage?
 
-	let span: Span
 	let subTraceId: TraceId?
 	let subtraceLinking: SubtraceLinking
 
-	/// Vend private attributes as a thread-safe copy
-	var attributes: TelemetryAttributes? {
-		lock.withLock { _attributes }
-	}
-
 	// MARK: Private
 
-	private let lock = OSAllocatedUnfairLock()
-
-	/// Carry arbitrary attributes:
-	private var _attributes: TelemetryAttributes?
+	/// Carry arbitrary attributes, guarded for thread-safe access:
+	private let _attributes: Mutex<TelemetryAttributes?>
 
 }

--- a/Sources/NautilusTelemetry/Tracing/Span.swift
+++ b/Sources/NautilusTelemetry/Tracing/Span.swift
@@ -59,7 +59,7 @@ public final class Span: TelemetryAttributesContainer, Identifiable {
 	) {
 		self.name = name
 		self.kind = kind
-		_attributes = Mutex(attributes)
+		_attributes = attributes
 		self.traceId = traceId
 		self.id = id
 		self.parentId = parentId
@@ -115,7 +115,7 @@ public final class Span: TelemetryAttributesContainer, Identifiable {
 	}
 
 	public func end() {
-		let callbacks = _attributes.withLock { _ in
+		let callbacks = lock.withLock { _ in
 			assert(endTime == nil, "span \(name) was ended more than once")
 
 			if let endTimeAdjustment {
@@ -147,18 +147,18 @@ public final class Span: TelemetryAttributesContainer, Identifiable {
 	public func addAttribute(_ name: String, _ value: AttributeValue?) {
 		guard let value else { return }
 
-		_attributes.withLock { attributes in
-			if attributes == nil {
-				attributes = TelemetryAttributes()
+		lock.withLock { _ in
+			if _attributes == nil {
+				_attributes = TelemetryAttributes()
 			}
 
-			attributes?[name] = value
+			_attributes?[name] = value
 		}
 	}
 
 	public subscript(name: String) -> AttributeValue? {
 		get {
-			_attributes.withLock { $0?[name] }
+			lock.withLock { _ in _attributes?[name] }
 		}
 		set(newValue) {
 			addAttribute(name, newValue)
@@ -166,7 +166,7 @@ public final class Span: TelemetryAttributesContainer, Identifiable {
 	}
 
 	public func addEvent(_ event: Event) {
-		_attributes.withLock { _ in
+		lock.withLock { _ in
 			if events == nil {
 				events = [Event]()
 			}
@@ -178,7 +178,7 @@ public final class Span: TelemetryAttributesContainer, Identifiable {
 	/// https://opentelemetry.io/docs/specs/semconv/registry/attributes/opentracing/
 	/// In lieu of an existing standard, we'll build something reasonable
 	public func addLink(_ span: Span, relationship: Link.Relationship = .undefined) {
-		_attributes.withLock { _ in
+		lock.withLock { _ in
 			links.append(Link(traceId: span.traceId, id: span.id, relationship: relationship))
 		}
 	}
@@ -264,7 +264,7 @@ public final class Span: TelemetryAttributesContainer, Identifiable {
 
 	/// Vend private attributes as a thread-safe copy
 	var attributes: TelemetryAttributes? {
-		_attributes.withLock { $0 }
+		lock.withLock { _ in _attributes }
 	}
 
 	var elapsed: Duration? {
@@ -313,17 +313,18 @@ public final class Span: TelemetryAttributesContainer, Identifiable {
 	/// Adds an additional retire callback to enable metrics from spans.
 	/// - Parameter retireCallback: closure to be appended to retireCallbacks
 	func addRetireCallback(_ callback: @escaping (_: Span) -> Void) {
-		_attributes.withLock { _ in
+		lock.withLock { _ in
 			retireCallbacks.append(callback)
 		}
 	}
 
 	// MARK: Private
 
-	/// Carries arbitrary attributes. Its lock also serializes mutation of the other
-	/// mutable collections above (`events`, `links`, `retireCallbacks`, `endTime`),
-	/// matching the single-lock design this type previously used.
-	private let _attributes: Mutex<TelemetryAttributes?>
+	/// Serializes mutation of the guarded mutable state (`_attributes`, `events`,
+	/// `links`, `retireCallbacks`, `endTime`).
+	private let lock = Mutex<Void>(())
+
+	private var _attributes: TelemetryAttributes?
 
 	private static func exceptionAttributes(type: String, message: String, stacktrace: String?) -> TelemetryAttributes {
 		var attributes: TelemetryAttributes = [

--- a/Sources/NautilusTelemetry/Tracing/Span.swift
+++ b/Sources/NautilusTelemetry/Tracing/Span.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-import os
+import Synchronization
 
 // MARK: - Link
 
@@ -59,7 +59,7 @@ public final class Span: TelemetryAttributesContainer, Identifiable {
 	) {
 		self.name = name
 		self.kind = kind
-		_attributes = attributes
+		_attributes = Mutex(attributes)
 		self.traceId = traceId
 		self.id = id
 		self.parentId = parentId
@@ -115,7 +115,7 @@ public final class Span: TelemetryAttributesContainer, Identifiable {
 	}
 
 	public func end() {
-		let callbacks = lock.withLock {
+		let callbacks = _attributes.withLock { _ in
 			assert(endTime == nil, "span \(name) was ended more than once")
 
 			if let endTimeAdjustment {
@@ -147,20 +147,18 @@ public final class Span: TelemetryAttributesContainer, Identifiable {
 	public func addAttribute(_ name: String, _ value: AttributeValue?) {
 		guard let value else { return }
 
-		lock.withLock {
-			if _attributes == nil {
-				_attributes = TelemetryAttributes()
+		_attributes.withLock { attributes in
+			if attributes == nil {
+				attributes = TelemetryAttributes()
 			}
 
-			_attributes?[name] = value
+			attributes?[name] = value
 		}
 	}
 
 	public subscript(name: String) -> AttributeValue? {
 		get {
-			lock.withLock {
-				_attributes?[name]
-			}
+			_attributes.withLock { $0?[name] }
 		}
 		set(newValue) {
 			addAttribute(name, newValue)
@@ -168,7 +166,7 @@ public final class Span: TelemetryAttributesContainer, Identifiable {
 	}
 
 	public func addEvent(_ event: Event) {
-		lock.withLock {
+		_attributes.withLock { _ in
 			if events == nil {
 				events = [Event]()
 			}
@@ -180,7 +178,7 @@ public final class Span: TelemetryAttributesContainer, Identifiable {
 	/// https://opentelemetry.io/docs/specs/semconv/registry/attributes/opentracing/
 	/// In lieu of an existing standard, we'll build something reasonable
 	public func addLink(_ span: Span, relationship: Link.Relationship = .undefined) {
-		lock.withLock {
+		_attributes.withLock { _ in
 			links.append(Link(traceId: span.traceId, id: span.id, relationship: relationship))
 		}
 	}
@@ -266,7 +264,7 @@ public final class Span: TelemetryAttributesContainer, Identifiable {
 
 	/// Vend private attributes as a thread-safe copy
 	var attributes: TelemetryAttributes? {
-		lock.withLock { _attributes }
+		_attributes.withLock { $0 }
 	}
 
 	var elapsed: Duration? {
@@ -315,16 +313,17 @@ public final class Span: TelemetryAttributesContainer, Identifiable {
 	/// Adds an additional retire callback to enable metrics from spans.
 	/// - Parameter retireCallback: closure to be appended to retireCallbacks
 	func addRetireCallback(_ callback: @escaping (_: Span) -> Void) {
-		lock.withLock {
+		_attributes.withLock { _ in
 			retireCallbacks.append(callback)
 		}
 	}
 
 	// MARK: Private
 
-	private let lock = OSAllocatedUnfairLock()
-
-	private var _attributes: TelemetryAttributes?
+	/// Carries arbitrary attributes. Its lock also serializes mutation of the other
+	/// mutable collections above (`events`, `links`, `retireCallbacks`, `endTime`),
+	/// matching the single-lock design this type previously used.
+	private let _attributes: Mutex<TelemetryAttributes?>
 
 	private static func exceptionAttributes(type: String, message: String, stacktrace: String?) -> TelemetryAttributes {
 		var attributes: TelemetryAttributes = [

--- a/Sources/NautilusTelemetry/Tracing/Tracer+Metrics.swift
+++ b/Sources/NautilusTelemetry/Tracing/Tracer+Metrics.swift
@@ -32,7 +32,7 @@ extension Tracer {
 	) -> Counter<Int> {
 		let name = metricName(span: span, namingConvention: namingConvention, fileID: fileID, suffix: "_counter")
 
-		let counter = _retiredSpans.withLock { _ in
+		let counter = lock.withLock { _ in
 			if let counter = cachedCounters[name]?.value { return counter }
 			let counter: Counter<Int> = InstrumentationSystem.meter.createCounter(
 				name: name,
@@ -69,7 +69,7 @@ extension Tracer {
 	) -> ExponentialHistogram<Int> {
 		let name = metricName(span: span, namingConvention: namingConvention, fileID: fileID, suffix: "_histogram")
 
-		let histogram = _retiredSpans.withLock { _ in
+		let histogram = lock.withLock { _ in
 			if let histogram = cachedDurationHistograms[name]?.value { return histogram }
 			let histogram: ExponentialHistogram<Int> = InstrumentationSystem.meter.createExponentialHistogram(
 				name: name,

--- a/Sources/NautilusTelemetry/Tracing/Tracer+Metrics.swift
+++ b/Sources/NautilusTelemetry/Tracing/Tracer+Metrics.swift
@@ -32,7 +32,7 @@ extension Tracer {
 	) -> Counter<Int> {
 		let name = metricName(span: span, namingConvention: namingConvention, fileID: fileID, suffix: "_counter")
 
-		let counter = lock.withLock {
+		let counter = _retiredSpans.withLock { _ in
 			if let counter = cachedCounters[name]?.value { return counter }
 			let counter: Counter<Int> = InstrumentationSystem.meter.createCounter(
 				name: name,
@@ -69,7 +69,7 @@ extension Tracer {
 	) -> ExponentialHistogram<Int> {
 		let name = metricName(span: span, namingConvention: namingConvention, fileID: fileID, suffix: "_histogram")
 
-		let histogram = lock.withLock {
+		let histogram = _retiredSpans.withLock { _ in
 			if let histogram = cachedDurationHistograms[name]?.value { return histogram }
 			let histogram: ExponentialHistogram<Int> = InstrumentationSystem.meter.createExponentialHistogram(
 				name: name,

--- a/Sources/NautilusTelemetry/Tracing/Tracer.swift
+++ b/Sources/NautilusTelemetry/Tracing/Tracer.swift
@@ -53,7 +53,7 @@ public final class Tracer {
 	}
 
 	public var root: Span {
-		_retiredSpans.withLock { _ in
+		lock.withLock { _ in
 			if let root = _root {
 				return root
 			} else {
@@ -68,7 +68,7 @@ public final class Tracer {
 	public func flushTrace() {
 		idleTimer?.suspend()
 
-		let priorRoot = _retiredSpans.withLock { _ -> Span? in
+		let priorRoot = lock.withLock { _ -> Span? in
 			let priorRoot = _root
 			traceId = Identifiers.generateTraceId()
 			_root = nil // will be recreated on next access
@@ -238,12 +238,10 @@ public final class Tracer {
 	// MARK: Internal
 
 	var traceId = Identifiers.generateTraceId()
+	var retiredSpans = [Span]()
 
 	/// Protects internal mutable state: `retiredSpans`, `traceId`, `_root`, and the metric caches.
-	let _retiredSpans = Mutex<[Span]>([])
-
-	/// Thread-safe snapshot of the retired spans awaiting flush.
-	var retiredSpans: [Span] { _retiredSpans.withLock { $0 } }
+	let lock = Mutex<Void>(())
 
 	/// Optional to avoid initialization order issue
 	var flushTimer: FlushTimer? = nil
@@ -275,8 +273,8 @@ public final class Tracer {
 	}
 
 	func retire(span: Span) {
-		_retiredSpans.withLock {
-			$0.append(span)
+		lock.withLock { _ in
+			retiredSpans.append(span)
 		}
 
 		// Push the timeout ahead
@@ -287,7 +285,7 @@ public final class Tracer {
 		// These are long-lived in normal usage, but clean up on flush for completeness.
 		purgeStaleCacheEntries()
 
-		let spansToReport: [Span] = _retiredSpans.withLock { retiredSpans in
+		let spansToReport: [Span] = lock.withLock { _ in
 			// copy and empty the array.
 			let spans = retiredSpans
 			retiredSpans.removeAll()
@@ -373,7 +371,7 @@ public final class Tracer {
 
 	/// Removes entries whose weak references have been deallocated.
 	private func purgeStaleCacheEntries() {
-		_retiredSpans.withLock { _ in
+		lock.withLock { _ in
 			cachedDurationHistograms = cachedDurationHistograms.filter { $0.value.value != nil }
 			cachedCounters = cachedCounters.filter { $0.value.value != nil }
 		}

--- a/Sources/NautilusTelemetry/Tracing/Tracer.swift
+++ b/Sources/NautilusTelemetry/Tracing/Tracer.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-import os
+import Synchronization
 
 public final class Tracer {
 
@@ -53,7 +53,7 @@ public final class Tracer {
 	}
 
 	public var root: Span {
-		lock.withLock {
+		_retiredSpans.withLock { _ in
 			if let root = _root {
 				return root
 			} else {
@@ -68,7 +68,7 @@ public final class Tracer {
 	public func flushTrace() {
 		idleTimer?.suspend()
 
-		let priorRoot = lock.withLock {
+		let priorRoot = _retiredSpans.withLock { _ -> Span? in
 			let priorRoot = _root
 			traceId = Identifiers.generateTraceId()
 			_root = nil // will be recreated on next access
@@ -237,10 +237,13 @@ public final class Tracer {
 
 	// MARK: Internal
 
-	let lock = OSAllocatedUnfairLock()
-
 	var traceId = Identifiers.generateTraceId()
-	var retiredSpans = [Span]()
+
+	/// Protects internal mutable state: `retiredSpans`, `traceId`, `_root`, and the metric caches.
+	let _retiredSpans = Mutex<[Span]>([])
+
+	/// Thread-safe snapshot of the retired spans awaiting flush.
+	var retiredSpans: [Span] { _retiredSpans.withLock { $0 } }
 
 	/// Optional to avoid initialization order issue
 	var flushTimer: FlushTimer? = nil
@@ -272,8 +275,8 @@ public final class Tracer {
 	}
 
 	func retire(span: Span) {
-		lock.withLock {
-			retiredSpans.append(span)
+		_retiredSpans.withLock {
+			$0.append(span)
 		}
 
 		// Push the timeout ahead
@@ -284,7 +287,7 @@ public final class Tracer {
 		// These are long-lived in normal usage, but clean up on flush for completeness.
 		purgeStaleCacheEntries()
 
-		let spansToReport: [Span] = lock.withLock {
+		let spansToReport: [Span] = _retiredSpans.withLock { retiredSpans in
 			// copy and empty the array.
 			let spans = retiredSpans
 			retiredSpans.removeAll()
@@ -370,7 +373,7 @@ public final class Tracer {
 
 	/// Removes entries whose weak references have been deallocated.
 	private func purgeStaleCacheEntries() {
-		lock.withLock {
+		_retiredSpans.withLock { _ in
 			cachedDurationHistograms = cachedDurationHistograms.filter { $0.value.value != nil }
 			cachedCounters = cachedCounters.filter { $0.value.value != nil }
 		}

--- a/Sources/NautilusTelemetry/Utilities/AttributeValue.swift
+++ b/Sources/NautilusTelemetry/Utilities/AttributeValue.swift
@@ -104,6 +104,7 @@ extension AttributeValue {
 			self = .string("\(value)")
 		}
 	}
+
 	public init(_ value: Double) { self = .double(value) }
 	public init(_ value: Float) { self = .double(Double(value)) }
 	public init(_ value: Bool) { self = .bool(value) }

--- a/Sources/NautilusTelemetry/Utilities/FlushTimer.swift
+++ b/Sources/NautilusTelemetry/Utilities/FlushTimer.swift
@@ -2,7 +2,7 @@
 // Copyright © 2025 Airbnb Inc. All rights reserved.
 
 import Foundation
-import os
+import Synchronization
 
 // MARK: - FlushTimer
 
@@ -29,7 +29,7 @@ class FlushTimer {
 
 	let flushTimer: DispatchSourceTimer
 
-	var suspended = false
+	var suspended: Bool { _suspended.withLock { $0 } }
 
 	let minimumFlushInterval: TimeInterval = 0.1
 	let repeating: Bool
@@ -43,7 +43,7 @@ class FlushTimer {
 	}
 
 	func suspend() {
-		lock.withLock {
+		_suspended.withLock { suspended in
 			if !suspended {
 				// Must match calls between suspend/resume
 				flushTimer.suspend()
@@ -62,7 +62,7 @@ class FlushTimer {
 			leeway: DispatchTimeInterval.milliseconds(100)
 		)
 		flushTimer.activate()
-		lock.withLock {
+		_suspended.withLock { suspended in
 			if suspended {
 				flushTimer.resume()
 				suspended = false
@@ -73,7 +73,7 @@ class FlushTimer {
 	// MARK: Private
 
 	private var _flushInterval: TimeInterval
-	private var lock = OSAllocatedUnfairLock()
+	private let _suspended = Mutex(false)
 }
 
 extension DispatchTimeInterval {

--- a/Sources/NautilusTelemetry/Utilities/FlushTimer.swift
+++ b/Sources/NautilusTelemetry/Utilities/FlushTimer.swift
@@ -29,10 +29,10 @@ class FlushTimer {
 
 	let flushTimer: DispatchSourceTimer
 
-	var suspended: Bool { _suspended.withLock { $0 } }
-
 	let minimumFlushInterval: TimeInterval = 0.1
 	let repeating: Bool
+
+	var suspended: Bool { _suspended.withLock { $0 } }
 
 	var flushInterval: TimeInterval {
 		get { _flushInterval }

--- a/Sources/NautilusTelemetry/Utilities/Sampling.swift
+++ b/Sources/NautilusTelemetry/Utilities/Sampling.swift
@@ -7,7 +7,7 @@
 
 import CryptoKit
 import Foundation
-import os
+import Synchronization
 
 // MARK: - Sampler
 
@@ -31,7 +31,7 @@ public final class StableGuidSampler: Sampler {
 	public init(sampleRate: Double, seed: Data, guid: Data) {
 		self.sampleRate = sampleRate
 		self.seed = seed
-		_guid = guid
+		_guid = Mutex(guid)
 		shouldSample = false
 		computeShouldSample()
 	}
@@ -54,18 +54,18 @@ public final class StableGuidSampler: Sampler {
 	public var guid: Data {
 		// actors would be great here!
 		get {
-			lock.withLock { _guid }
+			_guid.withLock { $0 }
 		}
 
 		set {
 			assert(newValue.count >= 0, "expected at least 1 byte of data")
 
-			var didChange = false
-			lock.withLockUnchecked {
-				if newValue != _guid {
-					_guid = newValue
-					didChange = true
+			let didChange = _guid.withLock { guid in
+				if newValue != guid {
+					guid = newValue
+					return true
 				}
+				return false
 			}
 
 			if didChange {
@@ -98,8 +98,6 @@ public final class StableGuidSampler: Sampler {
 
 	// MARK: Private
 
-	private let lock = OSAllocatedUnfairLock()
-
-	private var _guid: Data
+	private let _guid: Mutex<Data>
 
 }

--- a/Sources/SampleCode/ExampleReporter.swift
+++ b/Sources/SampleCode/ExampleReporter.swift
@@ -7,7 +7,7 @@
 //
 
 import Foundation
-import os
+import Synchronization
 #if canImport(UIKit)
 import UIKit
 #endif
@@ -78,8 +78,6 @@ public class ExampleReporter: NautilusTelemetryReporter {
 		case failure
 	}
 
-	static let lock = OSAllocatedUnfairLock()
-
 	static var userAgent: String = {
 		let bundle = Bundle.main
 		let bundleIdentifier = bundle.bundleIdentifier ?? "unknown"
@@ -91,12 +89,12 @@ public class ExampleReporter: NautilusTelemetryReporter {
 	static let sampler = StableGuidSampler(sampleRate: 1.0, seed: samplerSeed, guid: sessionGUID)
 
 	static var sessionGUID: Data {
-		lock.withLock {
-			if let guid = _sessionGUID {
+		_sessionGUID.withLock { sessionGUID in
+			if let guid = sessionGUID {
 				return guid
 			} else {
 				let guid = Identifiers.generateSessionGUID()
-				_sessionGUID = guid
+				sessionGUID = guid
 				return guid
 			}
 		}
@@ -119,8 +117,8 @@ public class ExampleReporter: NautilusTelemetryReporter {
 	let urlSession: URLSession
 
 	static func resetSessionGUID() {
-		lock.withLock {
-			_sessionGUID = nil
+		_sessionGUID.withLock {
+			$0 = nil
 		}
 	}
 
@@ -185,6 +183,6 @@ public class ExampleReporter: NautilusTelemetryReporter {
 
 	// MARK: Private
 
-	static private var _sessionGUID: Data?
+	static private let _sessionGUID = Mutex<Data?>(nil)
 
 }

--- a/Tests/NautilusTelemetryTests/Metrics/ObservableGaugeTests.swift
+++ b/Tests/NautilusTelemetryTests/Metrics/ObservableGaugeTests.swift
@@ -144,7 +144,7 @@ final class ObservableGaugeTests: XCTestCase {
 		XCTAssertFalse(gauge.isEmpty)
 
 		// Even after reset, gauges are never empty
-		gauge.values.reset()
+		_ = gauge.snapshotAndReset()
 		XCTAssertFalse(gauge.isEmpty)
 	}
 

--- a/Tests/NautilusTelemetryTests/Metrics/UpDownCounterTests.swift
+++ b/Tests/NautilusTelemetryTests/Metrics/UpDownCounterTests.swift
@@ -396,7 +396,7 @@ final class UpDownCounterTests: XCTestCase {
 		XCTAssertEqual(counter.values.valueFor(attributes: [:]), Int.max)
 
 		// Reset and test minimum value
-		counter.values.reset()
+		_ = counter.snapshotAndReset()
 		counter.add(Int.min)
 		XCTAssertEqual(counter.values.valueFor(attributes: [:]), Int.min)
 		XCTAssertFalse(counter.isEmpty)

--- a/Tests/NautilusTelemetryTests/Tracing/Span+URLSessionTests.swift
+++ b/Tests/NautilusTelemetryTests/Tracing/Span+URLSessionTests.swift
@@ -237,6 +237,8 @@ final class SpanURLSessionTests: XCTestCase {
 
 private final class MetricsCapturingDelegate: NSObject, URLSessionTaskDelegate, Sendable {
 
+	// MARK: Internal
+
 	var capturedMetrics: URLSessionTaskMetrics? {
 		mutex.withLock { $0 }
 	}
@@ -244,6 +246,8 @@ private final class MetricsCapturingDelegate: NSObject, URLSessionTaskDelegate, 
 	func urlSession(_: URLSession, task _: URLSessionTask, didFinishCollecting metrics: URLSessionTaskMetrics) {
 		mutex.withLock { $0 = metrics }
 	}
+
+	// MARK: Private
 
 	private let mutex: Mutex<URLSessionTaskMetrics?> = Mutex(nil)
 

--- a/Tests/NautilusTelemetryTests/Utilities/FlushTimerTests.swift
+++ b/Tests/NautilusTelemetryTests/Utilities/FlushTimerTests.swift
@@ -86,33 +86,50 @@ final class FlushTimerTests: XCTestCase {
 	}
 
 	func testFlushTimerSuspendAndResume() throws {
-		let expectation1 = XCTestExpectation(description: "Timer handler called before suspend")
-		let expectation2 = XCTestExpectation(description: "Timer handler called after resume")
+		let firstFire = XCTestExpectation(description: "Timer handler called before suspend")
+		let resumedFire = XCTestExpectation(description: "Timer handler called after resume")
+		// The resumed timer keeps firing, so allow the post-resume expectation to be met more than once.
+		resumedFire.assertForOverFulfill = false
+
+		// The handler runs on a background queue, so guard the shared counter against the test thread.
+		let lock = NSLock()
 		var handlerCallCount = 0
+		// Fires past this baseline (captured just before resuming) prove the timer resumed.
+		var resumeBaseline = Int.max
 
 		let timer = FlushTimer(flushInterval: 0.2, repeating: true) {
-			handlerCallCount += 1
-			if handlerCallCount == 1 {
-				expectation1.fulfill()
-			} else if handlerCallCount == 2 {
-				expectation2.fulfill()
+			lock.withLock {
+				handlerCallCount += 1
+				if handlerCallCount == 1 {
+					firstFire.fulfill()
+				}
+				if handlerCallCount > resumeBaseline {
+					resumedFire.fulfill()
+				}
 			}
 		}
 
-		wait(for: [expectation1], timeout: 1.0)
-		XCTAssertEqual(handlerCallCount, 1)
+		// 1. The running timer fires at least once.
+		wait(for: [firstFire], timeout: timeout)
 
+		// 2. While suspended, the timer must not fire again. Snapshot the count at suspend
+		// rather than asserting an exact value, since the running timer may have fired more
+		// than once before suspend took effect.
 		timer.suspend()
 		XCTAssertTrue(timer.suspended)
 
+		// Drain any handler invocation already in flight when we suspended, so the
+		// snapshot below reflects a quiesced timer (the queue is serial).
+		NautilusTelemetry.queue.sync {}
+		let countAtSuspend = lock.withLock { handlerCallCount }
 		Thread.sleep(forTimeInterval: 0.3)
-		XCTAssertEqual(handlerCallCount, 1)
+		XCTAssertEqual(lock.withLock { handlerCallCount }, countAtSuspend, "suspended timer must not fire")
 
+		// 3. Changing the interval resumes the timer, which fires again.
+		lock.withLock { resumeBaseline = countAtSuspend }
 		timer.flushInterval = 0.1
-
 		XCTAssertFalse(timer.suspended)
 
-		wait(for: [expectation2], timeout: timeout)
-		XCTAssertEqual(handlerCallCount, 2)
+		wait(for: [resumedFire], timeout: timeout)
 	}
 }

--- a/Tests/NautilusTelemetryTests/Utilities/FlushTimerTests.swift
+++ b/Tests/NautilusTelemetryTests/Utilities/FlushTimerTests.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import Synchronization
 import XCTest
 
 @testable import NautilusTelemetry
@@ -91,19 +92,21 @@ final class FlushTimerTests: XCTestCase {
 		// The resumed timer keeps firing, so allow the post-resume expectation to be met more than once.
 		resumedFire.assertForOverFulfill = false
 
-		// The handler runs on a background queue, so guard the shared counter against the test thread.
-		let lock = NSLock()
-		var handlerCallCount = 0
-		// Fires past this baseline (captured just before resuming) prove the timer resumed.
-		var resumeBaseline = Int.max
+		// The handler runs on a background queue, so guard the shared state against the test thread.
+		// `resumeBaseline` is captured just before resuming; fires past it prove the timer resumed.
+		struct State {
+			var handlerCallCount = 0
+			var resumeBaseline = Int.max
+		}
+		let state = Mutex(State())
 
 		let timer = FlushTimer(flushInterval: 0.2, repeating: true) {
-			lock.withLock {
-				handlerCallCount += 1
-				if handlerCallCount == 1 {
+			state.withLock { state in
+				state.handlerCallCount += 1
+				if state.handlerCallCount == 1 {
 					firstFire.fulfill()
 				}
-				if handlerCallCount > resumeBaseline {
+				if state.handlerCallCount > state.resumeBaseline {
 					resumedFire.fulfill()
 				}
 			}
@@ -121,12 +124,12 @@ final class FlushTimerTests: XCTestCase {
 		// Drain any handler invocation already in flight when we suspended, so the
 		// snapshot below reflects a quiesced timer (the queue is serial).
 		NautilusTelemetry.queue.sync {}
-		let countAtSuspend = lock.withLock { handlerCallCount }
+		let countAtSuspend = state.withLock { $0.handlerCallCount }
 		Thread.sleep(forTimeInterval: 0.3)
-		XCTAssertEqual(lock.withLock { handlerCallCount }, countAtSuspend, "suspended timer must not fire")
+		XCTAssertEqual(state.withLock { $0.handlerCallCount }, countAtSuspend, "suspended timer must not fire")
 
 		// 3. Changing the interval resumes the timer, which fires again.
-		lock.withLock { resumeBaseline = countAtSuspend }
+		state.withLock { $0.resumeBaseline = countAtSuspend }
 		timer.flushInterval = 0.1
 		XCTAssertFalse(timer.suspended)
 


### PR DESCRIPTION

## Summary

Migrates locking from `os.OSAllocatedUnfairLock` to `Mutex` from the `Synchronization` framework. This is a slight efficiency improvement (avoids an allocation), and wrapping the object is safer/clearer.

Where the lock guarded a single object, the `Mutex` now wraps that object directly:

- **`Baggage`** → `Mutex<TelemetryAttributes?>` (also resolves the prior "stored property is mutable" Swift 6 warning)
- **`Meter`** → `Mutex<[Instrument]>` (active instruments)
- **`Counter` / `ObservableCounter` / `ObservableUpDownCounter` / `ObservableGauge` / `Histogram` / `ExponentialHistogram`** → `Mutex` wrapping the instrument's `values`
- **`FlushTimer`** → `Mutex<Bool>` (suspended flag)
- **`StableGuidSampler`** → `Mutex<Data>` (GUID); the `withLockUnchecked` set path became a normal `withLock`
- **`ExampleReporter`** → `static Mutex<Data?>` (session GUID)

`Span` and `Tracer` guarded several heterogeneous fields (some read elsewhere without locking), so they keep a **single** mutex that also serializes those fields, preserving the prior single-lock semantics. Read-only computed accessors were added where the wrapped value was previously a directly-readable stored property, to avoid churning the exporter and test call sites.

Also adds public get accessors for `span` and `attributes` on `Baggage`, for better ergonomics in client code.

## Test plan

- `swift build` — clean (only the pre-existing `Baggage.span` non-Sendable warning remains)
- `swift test` — all 92 tests pass
- Two tests that mutated through `.values.reset()` were updated to `snapshotAndReset()`, since `values` is now a read-only snapshot

@jparise 
@bachand