### PR TITLE
Add metric exemplar support

### DIFF
--- a/Sources/NautilusTelemetry/Exporters/Exporter+Metrics.swift
+++ b/Sources/NautilusTelemetry/Exporters/Exporter+Metrics.swift
@@ -363,7 +363,7 @@ extension Exporter {
 	/// - Returns: the matching exemplars, or `nil` if there are none.
 	func convertToOTLP<T>(exemplars: [Exemplar<T>], metricAttributes: TelemetryAttributes) -> [OTLP.V1Exemplar]? {
 		let matching = exemplars.filter { exemplarSamplingDecision($0.span) && $0.attributes == metricAttributes }
-		guard matching.count > 0 else { return nil }
+		guard !matching.isEmpty else { return nil }
 
 		return matching.map { exemplar in
 			let span = exemplar.span

--- a/Sources/NautilusTelemetry/Exporters/Exporter+Metrics.swift
+++ b/Sources/NautilusTelemetry/Exporters/Exporter+Metrics.swift
@@ -53,6 +53,7 @@ extension Exporter {
 
 	func exportOTLP<T>(counter: Counter<T>) -> OTLP.V1Metric {
 		let values = counter.values.values
+		let exemplars = counter.exemplars
 		var dataPoints = [OTLP.V1NumberDataPoint]()
 
 		for key in values.keys {
@@ -74,7 +75,7 @@ extension Exporter {
 				timeUnixNano: timeUnixNano,
 				asDouble: doubleValue,
 				asInt: intValueString,
-				exemplars: nil, // no exemplar support yet
+				exemplars: convertToOTLP(exemplars: exemplars, key: key),
 				flags: nil
 			) // no flags support yet
 
@@ -101,6 +102,7 @@ extension Exporter {
 
 	func exportOTLP<T>(counter: ObservableCounter<T>) -> OTLP.V1Metric {
 		let values = counter.values.values
+		let exemplars = counter.exemplars
 		var dataPoints = [OTLP.V1NumberDataPoint]()
 
 		for key in values.keys {
@@ -122,7 +124,7 @@ extension Exporter {
 				timeUnixNano: timeUnixNano,
 				asDouble: doubleValue,
 				asInt: intValueString,
-				exemplars: nil, // no exemplar support yet
+				exemplars: convertToOTLP(exemplars: exemplars, key: key),
 				flags: nil // no flags support yet
 			)
 
@@ -149,6 +151,7 @@ extension Exporter {
 
 	func exportOTLP<T>(counter: ObservableUpDownCounter<T>) -> OTLP.V1Metric {
 		let values = counter.values.values
+		let exemplars = counter.exemplars
 		var dataPoints = [OTLP.V1NumberDataPoint]()
 
 		for key in values.keys {
@@ -170,7 +173,7 @@ extension Exporter {
 				timeUnixNano: timeUnixNano,
 				asDouble: doubleValue,
 				asInt: intValueString,
-				exemplars: nil, // no exemplar support yet
+				exemplars: convertToOTLP(exemplars: exemplars, key: key),
 				flags: nil
 			) // no flags support yet
 
@@ -197,6 +200,7 @@ extension Exporter {
 
 	func exportOTLP<T>(gauge: ObservableGauge<T>) -> OTLP.V1Metric {
 		let values = gauge.values.values
+		let exemplars = gauge.exemplars
 		var dataPoints = [OTLP.V1NumberDataPoint]()
 
 		for key in values.keys {
@@ -218,7 +222,7 @@ extension Exporter {
 				timeUnixNano: timeUnixNano,
 				asDouble: doubleValue,
 				asInt: intValueString,
-				exemplars: nil, // no exemplar support yet
+				exemplars: convertToOTLP(exemplars: exemplars, key: key),
 				flags: nil
 			) // no flags support yet
 
@@ -240,6 +244,7 @@ extension Exporter {
 
 	func exportOTLP<T>(histogram: Histogram<T>) -> OTLP.V1Metric {
 		let values = histogram.values.values
+		let exemplars = histogram.exemplars
 		var dataPoints = [OTLP.V1HistogramDataPoint]()
 
 		for key in values.keys {
@@ -263,7 +268,7 @@ extension Exporter {
 				sum: sum,
 				bucketCounts: bucketCounts,
 				explicitBounds: convertToOTLP(explicitBounds: value.explicitBounds),
-				exemplars: nil, // no exemplar support
+				exemplars: convertToOTLP(exemplars: exemplars, key: key),
 				flags: nil
 			)
 			dataPoints.append(dataPoint)
@@ -288,6 +293,7 @@ extension Exporter {
 
 	func exportOTLP<T>(histogram: ExponentialHistogram<T>) -> OTLP.V1Metric {
 		let values = histogram.values.values
+		let exemplars = histogram.exemplars
 		var dataPoints = [OTLP.V1ExponentialHistogramDataPoint]()
 
 		for key in values.keys {
@@ -322,7 +328,7 @@ extension Exporter {
 				positive: mapped.positive,
 				negative: mapped.negative,
 				flags: nil,
-				exemplars: nil, // no exemplar support
+				exemplars: convertToOTLP(exemplars: exemplars, key: key),
 				min: value.range.flatMap { asDouble($0.lowerBound) },
 				max: value.range.flatMap { asDouble($0.upperBound) },
 				zeroThreshold: nil
@@ -346,6 +352,35 @@ extension Exporter {
 			exponentialHistogram: v1ExponentialHistogram,
 			summary: nil
 		)
+	}
+
+	/// Converts the exemplars recorded under a given data point's aggregation key to OTLP.
+	/// Exemplars whose span is rejected by `exemplarSamplingDecision` are dropped, so a reporter can
+	/// attach exemplars only when the linked trace is sampled.
+	/// - Parameters:
+	///   - exemplars: all exemplars recorded on the instrument.
+	///   - key: the aggregation attributes identifying the data point.
+	/// - Returns: the matching exemplars, or `nil` if there are none.
+	func convertToOTLP<T>(exemplars: [Exemplar<T>], key: TelemetryAttributes) -> [OTLP.V1Exemplar]? {
+		let matching = exemplars.filter { $0.attributes == key && exemplarSamplingDecision($0.span) }
+		guard matching.count > 0 else { return nil }
+
+		return matching.map { exemplar in
+			let span = exemplar.span
+			// filtered_attributes are those recorded on the span but not already part of the data point's aggregation key.
+			let extraAttributes = span.attributes?.filter { key[$0.key] == nil } ?? [:]
+			let filteredAttributes = extraAttributes.isEmpty ? nil : convertToOTLP(attributes: extraAttributes)
+			let timeUnixNano = convertToOTLP(time: span.endTime ?? ContinuousClock.now)
+
+			return OTLP.V1Exemplar(
+				filteredAttributes: filteredAttributes,
+				timeUnixNano: timeUnixNano,
+				asDouble: asDouble(exemplar.value),
+				asInt: asIntString(exemplar.value),
+				spanId: span.id,
+				traceId: span.traceId
+			)
+		}
 	}
 
 	func convertToOTLP(bucketCounts: [UInt64]) -> [String] {

--- a/Sources/NautilusTelemetry/Exporters/Exporter+Metrics.swift
+++ b/Sources/NautilusTelemetry/Exporters/Exporter+Metrics.swift
@@ -75,7 +75,7 @@ extension Exporter {
 				timeUnixNano: timeUnixNano,
 				asDouble: doubleValue,
 				asInt: intValueString,
-				exemplars: convertToOTLP(exemplars: exemplars, key: key),
+				exemplars: convertToOTLP(exemplars: exemplars, metricAttributes: key),
 				flags: nil
 			) // no flags support yet
 
@@ -124,7 +124,7 @@ extension Exporter {
 				timeUnixNano: timeUnixNano,
 				asDouble: doubleValue,
 				asInt: intValueString,
-				exemplars: convertToOTLP(exemplars: exemplars, key: key),
+				exemplars: convertToOTLP(exemplars: exemplars, metricAttributes: key),
 				flags: nil // no flags support yet
 			)
 
@@ -173,7 +173,7 @@ extension Exporter {
 				timeUnixNano: timeUnixNano,
 				asDouble: doubleValue,
 				asInt: intValueString,
-				exemplars: convertToOTLP(exemplars: exemplars, key: key),
+				exemplars: convertToOTLP(exemplars: exemplars, metricAttributes: key),
 				flags: nil
 			) // no flags support yet
 
@@ -222,7 +222,7 @@ extension Exporter {
 				timeUnixNano: timeUnixNano,
 				asDouble: doubleValue,
 				asInt: intValueString,
-				exemplars: convertToOTLP(exemplars: exemplars, key: key),
+				exemplars: convertToOTLP(exemplars: exemplars, metricAttributes: key),
 				flags: nil
 			) // no flags support yet
 
@@ -268,7 +268,7 @@ extension Exporter {
 				sum: sum,
 				bucketCounts: bucketCounts,
 				explicitBounds: convertToOTLP(explicitBounds: value.explicitBounds),
-				exemplars: convertToOTLP(exemplars: exemplars, key: key),
+				exemplars: convertToOTLP(exemplars: exemplars, metricAttributes: key),
 				flags: nil
 			)
 			dataPoints.append(dataPoint)
@@ -328,7 +328,7 @@ extension Exporter {
 				positive: mapped.positive,
 				negative: mapped.negative,
 				flags: nil,
-				exemplars: convertToOTLP(exemplars: exemplars, key: key),
+				exemplars: convertToOTLP(exemplars: exemplars, metricAttributes: key),
 				min: value.range.flatMap { asDouble($0.lowerBound) },
 				max: value.range.flatMap { asDouble($0.upperBound) },
 				zeroThreshold: nil
@@ -354,21 +354,21 @@ extension Exporter {
 		)
 	}
 
-	/// Converts the exemplars recorded under a given data point's aggregation key to OTLP.
+	/// Converts the exemplars recorded under a given data point's set of attributes to OTLP.
 	/// Exemplars whose span is rejected by `exemplarSamplingDecision` are dropped, so a reporter can
 	/// attach exemplars only when the linked trace is sampled.
 	/// - Parameters:
 	///   - exemplars: all exemplars recorded on the instrument.
-	///   - key: the aggregation attributes identifying the data point.
+	///   - metricAttributes: the attributes associated with the metric.
 	/// - Returns: the matching exemplars, or `nil` if there are none.
-	func convertToOTLP<T>(exemplars: [Exemplar<T>], key: TelemetryAttributes) -> [OTLP.V1Exemplar]? {
-		let matching = exemplars.filter { $0.attributes == key && exemplarSamplingDecision($0.span) }
+	func convertToOTLP<T>(exemplars: [Exemplar<T>], metricAttributes: TelemetryAttributes) -> [OTLP.V1Exemplar]? {
+		let matching = exemplars.filter { exemplarSamplingDecision($0.span) && $0.attributes == metricAttributes }
 		guard matching.count > 0 else { return nil }
 
 		return matching.map { exemplar in
 			let span = exemplar.span
 			// filtered_attributes are those recorded on the span but not already part of the data point's aggregation key.
-			let extraAttributes = span.attributes?.filter { key[$0.key] == nil } ?? [:]
+			let extraAttributes = span.attributes?.filter { metricAttributes[$0.key] == nil } ?? [:]
 			let filteredAttributes = extraAttributes.isEmpty ? nil : convertToOTLP(attributes: extraAttributes)
 			let timeUnixNano = convertToOTLP(time: span.endTime ?? ContinuousClock.now)
 

--- a/Sources/NautilusTelemetry/Exporters/Exporter.swift
+++ b/Sources/NautilusTelemetry/Exporters/Exporter.swift
@@ -7,6 +7,13 @@
 
 import Foundation
 
+// MARK: - ExemplarSamplingDecision
+
+/// Decides whether the exemplar associated with a given span should be attached to exported metrics.
+/// Reporters typically drive this from the current trace sampling decision, so that exemplars — which
+/// link a metric data point back to a trace — are only attached when that trace is sampled.
+public typealias ExemplarSamplingDecision = (Span) -> Bool
+
 // MARK: - Exporter
 
 /// Provides conversions to OTLP-JSON format
@@ -15,10 +22,19 @@ public struct Exporter {
 	// MARK: Lifecycle
 
 	/// Initialize the exporter with a time reference.
-	/// - Parameter timeReference: describes the computed offset to server time.
-	public init(timeReference: TimeReference, prettyPrint: Bool = false) {
+	/// - Parameters:
+	///   - timeReference: describes the computed offset to server time.
+	///   - prettyPrint: whether JSON output should be pretty printed. Defaults to `false`.
+	///   - exemplarSamplingDecision: decides, per span, whether its exemplar is attached to exported metrics.
+	///     Defaults to attaching every exemplar. Reporters should pass their current sampling decision here.
+	public init(
+		timeReference: TimeReference,
+		prettyPrint: Bool = false,
+		exemplarSamplingDecision: @escaping ExemplarSamplingDecision = { _ in true }
+	) {
 		self.timeReference = timeReference
 		self.prettyPrint = prettyPrint
+		self.exemplarSamplingDecision = exemplarSamplingDecision
 	}
 
 	// MARK: Internal
@@ -30,6 +46,9 @@ public struct Exporter {
 
 	/// Should the JSON output be pretty printed? Defaults to false.
 	let prettyPrint: Bool
+
+	/// Decides whether a given span's exemplar is attached to exported metrics.
+	let exemplarSamplingDecision: ExemplarSamplingDecision
 
 	/// Encodes JSON, with Data objects encoded as hex.
 	/// - Returns: JSON data.

--- a/Sources/NautilusTelemetry/Metrics/Counter.swift
+++ b/Sources/NautilusTelemetry/Metrics/Counter.swift
@@ -31,6 +31,12 @@ public class Counter<T: MetricNumeric>: Instrument, ExportableInstrument {
 
 	public var isEmpty: Bool { lockedValues.withLock { $0.isEmpty } }
 
+	public var exemplarSpans: [Span] { lockedExemplars.withLock { $0.map(\.span) } }
+
+	public func addExemplar(span: Span, value: T, attributes: TelemetryAttributes = [:]) {
+		lockedExemplars.withLock { $0.append(Exemplar(span: span, value: value, attributes: attributes)) }
+	}
+
 	public func add(_ number: T, attributes: TelemetryAttributes = [:]) {
 		if isMonotonic, number < 0 {
 			// UpDownCounter is not monotonic
@@ -44,6 +50,10 @@ public class Counter<T: MetricNumeric>: Instrument, ExportableInstrument {
 
 	public func snapshotAndReset() -> Instrument {
 		let now = ContinuousClock.now
+		let exemplars = lockedExemplars.withLock { exemplars in
+			defer { exemplars.removeAll() }
+			return exemplars
+		}
 
 		return lockedValues.withLock { values in
 			let copy = Self(name: name, unit: unit, description: description)
@@ -51,6 +61,7 @@ public class Counter<T: MetricNumeric>: Instrument, ExportableInstrument {
 			copy.endTime = now
 			copy.aggregationTemporality = aggregationTemporality
 			copy.lockedValues.withLock { $0 = values.snapshotAndReset() }
+			copy.lockedExemplars.withLock { $0 = exemplars }
 
 			// now reset
 			startTime = now
@@ -65,6 +76,9 @@ public class Counter<T: MetricNumeric>: Instrument, ExportableInstrument {
 	/// Thread-safe snapshot of the recorded values.
 	var values: MetricValues<T> { lockedValues.withLock { $0 } }
 
+	/// Thread-safe snapshot of the recorded exemplars.
+	var exemplars: [Exemplar<T>] { lockedExemplars.withLock { $0 } }
+
 	func exportOTLP(_ exporter: Exporter) -> OTLP.V1Metric {
 		exporter.exportOTLP(counter: self)
 	}
@@ -74,4 +88,7 @@ public class Counter<T: MetricNumeric>: Instrument, ExportableInstrument {
 	/// Locking is handled at the Instrument level
 	/// The implementation must take care to avoid concurrently modifying values
 	private let lockedValues = Mutex(MetricValues<T>())
+
+	/// Exemplars recorded in the current collection interval.
+	private let lockedExemplars = Mutex<[Exemplar<T>]>([])
 }

--- a/Sources/NautilusTelemetry/Metrics/Exemplar.swift
+++ b/Sources/NautilusTelemetry/Metrics/Exemplar.swift
@@ -1,0 +1,30 @@
+//
+//  Exemplar.swift
+//
+//
+//  Created by Ladd Van Tol on 2026-07-15.
+//
+
+import Foundation
+
+/// A sample measurement recorded alongside the span that produced it.
+/// Exemplars link an aggregated metric data point back to a specific trace when it is sampled.
+/// https://opentelemetry.io/docs/specs/otel/metrics/data-model/#exemplars
+public struct Exemplar<T: MetricNumeric> {
+
+	/// The span active when the measurement was recorded.
+	public let span: Span
+
+	/// The recorded measurement value.
+	public let value: T
+
+	/// The aggregation attributes the measurement was recorded under.
+	/// Used to associate the exemplar with the matching data point.
+	public let attributes: TelemetryAttributes
+
+	public init(span: Span, value: T, attributes: TelemetryAttributes = [:]) {
+		self.span = span
+		self.value = value
+		self.attributes = attributes
+	}
+}

--- a/Sources/NautilusTelemetry/Metrics/ExponentialHistogram.swift
+++ b/Sources/NautilusTelemetry/Metrics/ExponentialHistogram.swift
@@ -47,6 +47,12 @@ public class ExponentialHistogram<T: MetricNumeric>: Instrument, ExportableInstr
 
 	public var isEmpty: Bool { lockedValues.withLock { $0.isEmpty } }
 
+	public var exemplarSpans: [Span] { lockedExemplars.withLock { $0.map(\.span) } }
+
+	public func addExemplar(span: Span, value: T, attributes: TelemetryAttributes = [:]) {
+		lockedExemplars.withLock { $0.append(Exemplar(span: span, value: value, attributes: attributes)) }
+	}
+
 	/// Record a value. Positive, negative, and zero values are all allowed (unlike `Histogram`),
 	/// since the spec maps them into separate positive/negative/zero buckets.
 	public func record(_ number: T, attributes: TelemetryAttributes = [:]) {
@@ -57,6 +63,10 @@ public class ExponentialHistogram<T: MetricNumeric>: Instrument, ExportableInstr
 
 	public func snapshotAndReset() -> Instrument {
 		let now = ContinuousClock.now
+		let exemplars = lockedExemplars.withLock { exemplars in
+			defer { exemplars.removeAll() }
+			return exemplars
+		}
 
 		return lockedValues.withLock { values in
 			let copy = Self(name: name, unit: unit, description: description, maxBuckets: maxBuckets)
@@ -64,6 +74,7 @@ public class ExponentialHistogram<T: MetricNumeric>: Instrument, ExportableInstr
 			copy.endTime = now
 			copy.aggregationTemporality = aggregationTemporality
 			copy.lockedValues.withLock { $0 = values.snapshotAndReset() }
+			copy.lockedExemplars.withLock { $0 = exemplars }
 
 			// now reset the instrument
 			startTime = now
@@ -78,6 +89,9 @@ public class ExponentialHistogram<T: MetricNumeric>: Instrument, ExportableInstr
 	/// Thread-safe snapshot of the recorded values.
 	var values: ExponentialHistogramValues<T> { lockedValues.withLock { $0 } }
 
+	/// Thread-safe snapshot of the recorded exemplars.
+	var exemplars: [Exemplar<T>] { lockedExemplars.withLock { $0 } }
+
 	func exportOTLP(_ exporter: Exporter) -> OTLP.V1Metric {
 		exporter.exportOTLP(histogram: self)
 	}
@@ -87,4 +101,7 @@ public class ExponentialHistogram<T: MetricNumeric>: Instrument, ExportableInstr
 	/// Locking is handled at the Instrument level
 	/// The implementation must take care to avoid concurrently modifying values
 	private let lockedValues: Mutex<ExponentialHistogramValues<T>>
+
+	/// Exemplars recorded in the current collection interval.
+	private let lockedExemplars = Mutex<[Exemplar<T>]>([])
 }

--- a/Sources/NautilusTelemetry/Metrics/Histogram.swift
+++ b/Sources/NautilusTelemetry/Metrics/Histogram.swift
@@ -36,6 +36,12 @@ public class Histogram<T: MetricNumeric>: Instrument, ExportableInstrument {
 
 	public var isEmpty: Bool { lockedValues.withLock { $0.isEmpty } }
 
+	public var exemplarSpans: [Span] { lockedExemplars.withLock { $0.map(\.span) } }
+
+	public func addExemplar(span: Span, value: T, attributes: TelemetryAttributes = [:]) {
+		lockedExemplars.withLock { $0.append(Exemplar(span: span, value: value, attributes: attributes)) }
+	}
+
 	public func record(_ number: T, attributes: TelemetryAttributes = [:]) {
 		if number < 0 {
 			assert(false, "histograms can only be increased")
@@ -49,6 +55,10 @@ public class Histogram<T: MetricNumeric>: Instrument, ExportableInstrument {
 
 	public func snapshotAndReset() -> Instrument {
 		let now = ContinuousClock.now
+		let exemplars = lockedExemplars.withLock { exemplars in
+			defer { exemplars.removeAll() }
+			return exemplars
+		}
 
 		return lockedValues.withLock { values in
 			let copy = Self(name: name, unit: unit, description: description, explicitBounds: values.explicitBounds)
@@ -56,6 +66,7 @@ public class Histogram<T: MetricNumeric>: Instrument, ExportableInstrument {
 			copy.endTime = now
 			copy.aggregationTemporality = aggregationTemporality
 			copy.lockedValues.withLock { $0 = values.snapshotAndReset() }
+			copy.lockedExemplars.withLock { $0 = exemplars }
 
 			// now reset the instrument
 			startTime = now
@@ -70,6 +81,9 @@ public class Histogram<T: MetricNumeric>: Instrument, ExportableInstrument {
 	/// Thread-safe snapshot of the recorded values.
 	var values: HistogramValues<T> { lockedValues.withLock { $0 } }
 
+	/// Thread-safe snapshot of the recorded exemplars.
+	var exemplars: [Exemplar<T>] { lockedExemplars.withLock { $0 } }
+
 	func exportOTLP(_ exporter: Exporter) -> OTLP.V1Metric {
 		exporter.exportOTLP(histogram: self)
 	}
@@ -79,4 +93,7 @@ public class Histogram<T: MetricNumeric>: Instrument, ExportableInstrument {
 	/// Locking is handled at the Instrument level
 	/// The implementation must take care to avoid concurrently modifying values
 	private let lockedValues: Mutex<HistogramValues<T>>
+
+	/// Exemplars recorded in the current collection interval.
+	private let lockedExemplars = Mutex<[Exemplar<T>]>([])
 }

--- a/Sources/NautilusTelemetry/Metrics/Instrument.swift
+++ b/Sources/NautilusTelemetry/Metrics/Instrument.swift
@@ -26,6 +26,11 @@ public protocol Instrument: AnyObject {
 
 	var aggregationTemporality: AggregationTemporality { get }
 
+	/// A list of spans associated with the measurement that may be reported as exemplars when the trace is sampled.
+	/// Exemplars are recorded with their measurement value via the concrete instrument's `addExemplar(span:value:attributes:)`,
+	/// which cannot be expressed on this non-generic protocol.
+	var exemplarSpans: [Span] { get }
+
 	/// In a thread safe manner:
 	///  - Invokes callback, if observable
 	///  - Captures a copy of the instrument at this moment in time

--- a/Sources/NautilusTelemetry/Metrics/ObservableCounter.swift
+++ b/Sources/NautilusTelemetry/Metrics/ObservableCounter.swift
@@ -32,6 +32,12 @@ public class ObservableCounter<T: MetricNumeric>: Instrument, ExportableInstrume
 
 	public var isEmpty: Bool { lockedValues.withLock { $0.isEmpty } }
 
+	public var exemplarSpans: [Span] { lockedExemplars.withLock { $0.map(\.span) } }
+
+	public func addExemplar(span: Span, value: T, attributes: TelemetryAttributes = [:]) {
+		lockedExemplars.withLock { $0.append(Exemplar(span: span, value: value, attributes: attributes)) }
+	}
+
 	/// https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/api.md#asynchronous-counter-creation
 	public func observe(_ number: T, attributes: TelemetryAttributes = [:]) {
 		lockedValues.withLock {
@@ -43,12 +49,18 @@ public class ObservableCounter<T: MetricNumeric>: Instrument, ExportableInstrume
 		let now = ContinuousClock.now
 		callback(self)
 
+		let exemplars = lockedExemplars.withLock { exemplars in
+			defer { exemplars.removeAll() }
+			return exemplars
+		}
+
 		return lockedValues.withLock { values in
 			let copy = Self(name: name, unit: unit, description: description, callback: callback)
 			copy.startTime = startTime
 			copy.endTime = now
 			copy.aggregationTemporality = aggregationTemporality
 			copy.lockedValues.withLock { $0 = values.snapshotAndReset() }
+			copy.lockedExemplars.withLock { $0 = exemplars }
 
 			// now reset
 			startTime = now
@@ -65,6 +77,9 @@ public class ObservableCounter<T: MetricNumeric>: Instrument, ExportableInstrume
 	/// Thread-safe snapshot of the recorded values.
 	var values: MetricValues<T> { lockedValues.withLock { $0 } }
 
+	/// Thread-safe snapshot of the recorded exemplars.
+	var exemplars: [Exemplar<T>] { lockedExemplars.withLock { $0 } }
+
 	func exportOTLP(_ exporter: Exporter) -> OTLP.V1Metric {
 		exporter.exportOTLP(counter: self)
 	}
@@ -74,4 +89,7 @@ public class ObservableCounter<T: MetricNumeric>: Instrument, ExportableInstrume
 	/// Locking is handled at the Instrument level
 	/// The implementation must take care to avoid concurrently modifying values
 	private let lockedValues = Mutex(MetricValues<T>())
+
+	/// Exemplars recorded in the current collection interval.
+	private let lockedExemplars = Mutex<[Exemplar<T>]>([])
 }

--- a/Sources/NautilusTelemetry/Metrics/ObservableGauge.swift
+++ b/Sources/NautilusTelemetry/Metrics/ObservableGauge.swift
@@ -30,6 +30,12 @@ public class ObservableGauge<T: MetricNumeric>: Instrument, ExportableInstrument
 
 	public var isEmpty: Bool { false }
 
+	public var exemplarSpans: [Span] { lockedExemplars.withLock { $0.map(\.span) } }
+
+	public func addExemplar(span: Span, value: T, attributes: TelemetryAttributes = [:]) {
+		lockedExemplars.withLock { $0.append(Exemplar(span: span, value: value, attributes: attributes)) }
+	}
+
 	public func observe(_ number: T, attributes: TelemetryAttributes = [:]) {
 		lockedValues.withLock {
 			$0.set(number, attributes: attributes)
@@ -40,11 +46,17 @@ public class ObservableGauge<T: MetricNumeric>: Instrument, ExportableInstrument
 		let now = ContinuousClock.now
 		callback(self)
 
+		let exemplars = lockedExemplars.withLock { exemplars in
+			defer { exemplars.removeAll() }
+			return exemplars
+		}
+
 		return lockedValues.withLock { values in
 			let copy = Self(name: name, unit: unit, description: description, callback: callback)
 			copy.startTime = startTime
 			copy.endTime = now
 			copy.lockedValues.withLock { $0 = values.snapshotAndReset() }
+			copy.lockedExemplars.withLock { $0 = exemplars }
 
 			// now reset
 			startTime = now
@@ -61,6 +73,9 @@ public class ObservableGauge<T: MetricNumeric>: Instrument, ExportableInstrument
 	/// Thread-safe snapshot of the recorded values.
 	var values: MetricValues<T> { lockedValues.withLock { $0 } }
 
+	/// Thread-safe snapshot of the recorded exemplars.
+	var exemplars: [Exemplar<T>] { lockedExemplars.withLock { $0 } }
+
 	func exportOTLP(_ exporter: Exporter) -> OTLP.V1Metric {
 		exporter.exportOTLP(gauge: self)
 	}
@@ -69,4 +84,7 @@ public class ObservableGauge<T: MetricNumeric>: Instrument, ExportableInstrument
 
 	/// Locking is handled at the Instrument level
 	private let lockedValues = Mutex(MetricValues<T>())
+
+	/// Exemplars recorded in the current collection interval.
+	private let lockedExemplars = Mutex<[Exemplar<T>]>([])
 }

--- a/Sources/NautilusTelemetry/Metrics/ObservableUpDownCounter.swift
+++ b/Sources/NautilusTelemetry/Metrics/ObservableUpDownCounter.swift
@@ -32,6 +32,12 @@ public class ObservableUpDownCounter<T: MetricNumeric>: Instrument, ExportableIn
 
 	public var isEmpty: Bool { lockedValues.withLock { $0.isEmpty } }
 
+	public var exemplarSpans: [Span] { lockedExemplars.withLock { $0.map(\.span) } }
+
+	public func addExemplar(span: Span, value: T, attributes: TelemetryAttributes = [:]) {
+		lockedExemplars.withLock { $0.append(Exemplar(span: span, value: value, attributes: attributes)) }
+	}
+
 	public func observe(_ number: T, attributes: TelemetryAttributes = [:]) {
 		lockedValues.withLock {
 			$0.set(number, attributes: attributes)
@@ -42,11 +48,17 @@ public class ObservableUpDownCounter<T: MetricNumeric>: Instrument, ExportableIn
 		let now = ContinuousClock.now
 		callback(self)
 
+		let exemplars = lockedExemplars.withLock { exemplars in
+			defer { exemplars.removeAll() }
+			return exemplars
+		}
+
 		return lockedValues.withLock { values in
 			let copy = Self(name: name, unit: unit, description: description, callback: callback)
 			copy.startTime = startTime
 			copy.endTime = now
 			copy.lockedValues.withLock { $0 = values.snapshotAndReset() }
+			copy.lockedExemplars.withLock { $0 = exemplars }
 
 			// now reset
 			startTime = now
@@ -63,6 +75,9 @@ public class ObservableUpDownCounter<T: MetricNumeric>: Instrument, ExportableIn
 	/// Thread-safe snapshot of the recorded values.
 	var values: MetricValues<T> { lockedValues.withLock { $0 } }
 
+	/// Thread-safe snapshot of the recorded exemplars.
+	var exemplars: [Exemplar<T>] { lockedExemplars.withLock { $0 } }
+
 	func exportOTLP(_ exporter: Exporter) -> OTLP.V1Metric {
 		exporter.exportOTLP(counter: self)
 	}
@@ -71,4 +86,7 @@ public class ObservableUpDownCounter<T: MetricNumeric>: Instrument, ExportableIn
 
 	/// Locking is handled at the Instrument level
 	private let lockedValues = Mutex(MetricValues<T>())
+
+	/// Exemplars recorded in the current collection interval.
+	private let lockedExemplars = Mutex<[Exemplar<T>]>([])
 }

--- a/Sources/NautilusTelemetry/Tracing/Span.swift
+++ b/Sources/NautilusTelemetry/Tracing/Span.swift
@@ -103,6 +103,7 @@ public final class Span: TelemetryAttributesContainer, Identifiable {
 	public let name: String
 	public let traceId: TraceId
 	public let id: SpanId
+	public let parentId: SpanId?
 	public let isRoot: Bool
 
 	/// Allows overriding the default sample rate for this span and its children.
@@ -250,7 +251,6 @@ public final class Span: TelemetryAttributesContainer, Identifiable {
 	// MARK: Internal
 
 	let kind: SpanKind
-	let parentId: SpanId?
 
 	/// Span references are converted  to `Link` to avoid cyclic references.
 	var links: [Link]

--- a/Sources/NautilusTelemetry/Tracing/Tracer+Metrics.swift
+++ b/Sources/NautilusTelemetry/Tracing/Tracer+Metrics.swift
@@ -14,6 +14,35 @@ extension Tracer {
 		case raw
 	}
 
+	/// The unit a duration histogram records in, exposed both as the metric's UCUM `unit` symbol and the
+	/// conversion applied to each recorded span duration.
+	public enum DurationUnit {
+		case seconds
+		case milliseconds
+		case microseconds
+		case nanoseconds
+
+		/// UCUM unit symbol reported as the metric's `unit`.
+		var symbol: String {
+			switch self {
+			case .seconds: "s"
+			case .milliseconds: "ms"
+			case .microseconds: "µs"
+			case .nanoseconds: "ns"
+			}
+		}
+
+		/// Converts a duration to a whole number of this unit, rounded half-away-from-zero.
+		func measurement(from duration: Duration) -> Int {
+			switch self {
+			case .seconds: Int(duration.asSeconds)
+			case .milliseconds: Int(duration.asMilliseconds)
+			case .microseconds: Int(duration.asMicroseconds)
+			case .nanoseconds: Int(duration.asNanoseconds)
+			}
+		}
+	}
+
 	/// Report span counts as an OTel Counter metric
 	/// The counter is strongly referenced through Meter's register, and a cached copy will be returned if the derived metric name matches.
 	/// Callers need only hold a reference to the counter if they need to later unregister.
@@ -53,11 +82,12 @@ extension Tracer {
 		return counter
 	}
 
-	/// Report span durations as an OTel ExponentialHistogram metric
+	/// Report span durations as an OTel ExponentialHistogram metric.
 	/// The histogram is strongly referenced through Meter's register, and a cached copy will be returned if the derived metric name matches.
 	/// Callers need only hold a reference to the histogram if they need to later unregister.
 	/// - Parameters:
 	///   - span: the span to measure. A metric name will be derived from the span name.
+	///   - unit: the time unit durations are recorded in, reported as the metric's `unit`. Defaults to milliseconds. A given metric name should always use the same unit, since the unit is fixed when the histogram is first created.
 	///   - namingConvention: determines how to derive the metric name
 	///   - fileID: fileID where the span was created, for module name determination.
 	///   - spanAttributeKeys: A set of attribute keys to collect from the span when it is ended. This set should be minimal to avoid metric cardinality explosion.
@@ -65,6 +95,7 @@ extension Tracer {
 	@discardableResult
 	public func reportAsDurationHistogramMetric(
 		span: Span,
+		unit: DurationUnit = .milliseconds,
 		namingConvention: MetricNamingConvention = .modulePrefix,
 		fileID: String = #fileID,
 		spanAttributeKeys: Set<String>? = nil
@@ -75,7 +106,7 @@ extension Tracer {
 			if let histogram = cachedDurationHistograms[name]?.value { return histogram }
 			let histogram: ExponentialHistogram<Int> = InstrumentationSystem.meter.createExponentialHistogram(
 				name: name,
-				unit: Unit(symbol: "ms"),
+				unit: Unit(symbol: unit.symbol),
 				description: "Created from span"
 			)
 			cachedDurationHistograms[name] = Weak(histogram)
@@ -84,7 +115,7 @@ extension Tracer {
 
 		span.addRetireCallback { [weak histogram] span in
 			guard let histogram, let elapsed = span.elapsed else { return }
-			let value = Int(elapsed.asMilliseconds)
+			let value = unit.measurement(from: elapsed)
 			let attributes = Self.collectAttributes(span, spanAttributeKeys)
 			histogram.record(value, attributes: attributes)
 			histogram.addExemplar(span: span, value: value, attributes: attributes)

--- a/Sources/NautilusTelemetry/Tracing/Tracer+Metrics.swift
+++ b/Sources/NautilusTelemetry/Tracing/Tracer+Metrics.swift
@@ -45,7 +45,9 @@ extension Tracer {
 
 		span.addRetireCallback { [weak counter] span in
 			guard let counter else { return }
-			counter.add(1, attributes: Self.collectAttributes(span, spanAttributeKeys))
+			let attributes = Self.collectAttributes(span, spanAttributeKeys)
+			counter.add(1, attributes: attributes)
+			counter.addExemplar(span: span, value: 1, attributes: attributes)
 		}
 
 		return counter
@@ -82,7 +84,10 @@ extension Tracer {
 
 		span.addRetireCallback { [weak histogram] span in
 			guard let histogram, let elapsed = span.elapsed else { return }
-			histogram.record(Int(elapsed.asMilliseconds), attributes: Self.collectAttributes(span, spanAttributeKeys))
+			let value = Int(elapsed.asMilliseconds)
+			let attributes = Self.collectAttributes(span, spanAttributeKeys)
+			histogram.record(value, attributes: attributes)
+			histogram.addExemplar(span: span, value: value, attributes: attributes)
 		}
 
 		return histogram

--- a/Sources/NautilusTelemetry/Utilities/TimeReference.swift
+++ b/Sources/NautilusTelemetry/Utilities/TimeReference.swift
@@ -56,26 +56,37 @@ extension Duration {
 	/// Duration as a whole number of nanoseconds, rounded half-away-from-zero.
 	/// Will overflow above ≈292 year duration.
 	var asNanoseconds: Int64 {
-		let attosecondsPerNs: Int128 = 1_000_000_000 // 10^9
-		let halfNs: Int128 = 500_000_000 // 5 × 10^8
-		let attos = attoseconds
-		let subNs = attos % attosecondsPerNs
-		let ns = attos / attosecondsPerNs + (subNs >= halfNs ? 1 : subNs <= -halfNs ? -1 : 0)
-		return Int64(ns)
+		wholeUnits(attosecondsPerUnit: 1_000_000_000) // 10^9
+	}
+
+	/// Duration as a whole number of microseconds, rounded half-away-from-zero.
+	/// Will overflow above ≈292 thousand year duration.
+	var asMicroseconds: Int64 {
+		wholeUnits(attosecondsPerUnit: 1_000_000_000_000) // 10^12
 	}
 
 	/// Duration as a whole number of milliseconds, rounded half-away-from-zero.
-	///
-	/// Uses `Duration.attoseconds` (Int128) directly, avoiding any precision loss from
-	/// intermediate truncation. The sub-millisecond remainder shares the sign of the
-	/// duration, so the half-ms threshold check needs no sign adjustment.
 	/// Will overflow above 292 million years.
 	var asMilliseconds: Int64 {
-		let attosecondsPerMs: Int128 = 1_000_000_000_000_000 // 10^15
-		let halfMs: Int128 = 500_000_000_000_000 // 5 × 10^14
+		wholeUnits(attosecondsPerUnit: 1_000_000_000_000_000) // 10^15
+	}
+
+	/// Duration as a whole number of seconds, rounded half-away-from-zero.
+	var asSeconds: Int64 {
+		wholeUnits(attosecondsPerUnit: 1_000_000_000_000_000_000) // 10^18
+	}
+
+	/// Converts the duration to a whole number of a unit, rounded half-away-from-zero.
+	///
+	/// Uses `Duration.attoseconds` (Int128) directly, avoiding any precision loss from intermediate
+	/// truncation. The sub-unit remainder shares the sign of the duration, so the half-unit threshold
+	/// check needs no sign adjustment.
+	/// - Parameter attosecondsPerUnit: attoseconds in one unit (e.g. `10^15` for a millisecond).
+	private func wholeUnits(attosecondsPerUnit: Int128) -> Int64 {
+		let half = attosecondsPerUnit / 2
 		let attos = attoseconds
-		let subMs = attos % attosecondsPerMs
-		let ms = attos / attosecondsPerMs + (subMs >= halfMs ? 1 : subMs <= -halfMs ? -1 : 0)
-		return Int64(ms)
+		let remainder = attos % attosecondsPerUnit
+		let whole = attos / attosecondsPerUnit + (remainder >= half ? 1 : remainder <= -half ? -1 : 0)
+		return Int64(whole)
 	}
 }

--- a/Sources/SampleCode/ExampleReporter.swift
+++ b/Sources/SampleCode/ExampleReporter.swift
@@ -60,15 +60,22 @@ public class ExampleReporter: NautilusTelemetryReporter {
 	}
 
 	public func reportInstruments(_ instruments: [Instrument]) {
+		// NOTE: This gates the entire metrics payload on the trace sampling decision. Metrics and traces
+		// don't have to share a sampling decision -- an app might always emit metrics while sampling traces,
+		// or sample the two at different rates. If so, replace this with a dedicated metrics sampling
+		// decision here, and keep `exemplarSamplingDecision` for whether trace exemplars are attached.
 		guard Self.samplingEnabled else {
 			return
 		}
 
 		let additionalAttributes: TelemetryAttributes = ["sample": "value"]
-		let exporter = Exporter(timeReference: timeReference)
+
+		// Exemplars link a data point back to a trace, so they are only attached when that trace would be
+		// sampled. We reuse the same per-span decision as `reportSpans`.
+		let exporter = Exporter(timeReference: timeReference, exemplarSamplingDecision: shouldSampleSpan)
 
 		if let jsonPayload = try? exporter.exportOTLPToJSON(instruments: instruments, additionalAttributes: additionalAttributes) {
-			try? dispatchPayload(jsonPayload: jsonPayload, url: traceEndpoint)
+			try? dispatchPayload(jsonPayload: jsonPayload, url: metricEndpoint)
 		}
 	}
 
@@ -124,12 +131,16 @@ public class ExampleReporter: NautilusTelemetryReporter {
 
 	/// Filters spans based on their sample rate override, falling back to `Self.samplingEnabled` when unset.
 	func sampledSpans(_ spans: [Span]) -> [Span] {
-		spans.filter { span in
-			if let sampleRate = span.sampleRate {
-				return StableGuidSampler(sampleRate: sampleRate, seed: Self.samplerSeed, guid: Self.sessionGUID).shouldSample
-			}
-			return Self.samplingEnabled
+		spans.filter { shouldSampleSpan($0) }
+	}
+
+	/// The sampling decision for a single span: honor a per-span `sampleRate` override, otherwise fall back
+	/// to `Self.samplingEnabled`. Used both to filter reported spans and to decide exemplar attachment.
+	func shouldSampleSpan(_ span: Span) -> Bool {
+		if let sampleRate = span.sampleRate {
+			return StableGuidSampler(sampleRate: sampleRate, seed: Self.samplerSeed, guid: Self.sessionGUID).shouldSample
 		}
+		return Self.samplingEnabled
 	}
 
 	// MARK: Lifecycle events

--- a/Tests/NautilusTelemetryTests/Metrics/MetricExporterTests.swift
+++ b/Tests/NautilusTelemetryTests/Metrics/MetricExporterTests.swift
@@ -134,13 +134,13 @@ struct MetricExporterTests {
 		let exporter = Exporter(timeReference: timeReference)
 
 		// Exemplars only attach to the data point sharing their aggregation key.
-		let homeExemplars = try #require(exporter.convertToOTLP(exemplars: counter.exemplars, key: home))
+		let homeExemplars = try #require(exporter.convertToOTLP(exemplars: counter.exemplars, metricAttributes: home))
 		#expect(homeExemplars.map(\.spanId) == [homeSpan.id])
 
-		let cartExemplars = try #require(exporter.convertToOTLP(exemplars: counter.exemplars, key: cart))
+		let cartExemplars = try #require(exporter.convertToOTLP(exemplars: counter.exemplars, metricAttributes: cart))
 		#expect(cartExemplars.map(\.spanId) == [cartSpan.id])
 
-		#expect(exporter.convertToOTLP(exemplars: counter.exemplars, key: ["route": "search"]) == nil)
+		#expect(exporter.convertToOTLP(exemplars: counter.exemplars, metricAttributes: ["route": "search"]) == nil)
 	}
 
 	@Test
@@ -159,16 +159,16 @@ struct MetricExporterTests {
 
 		// Decision drops everything: no exemplars are attached.
 		let noneExporter = Exporter(timeReference: timeReference, exemplarSamplingDecision: { _ in false })
-		#expect(noneExporter.convertToOTLP(exemplars: counter.exemplars, key: [:]) == nil)
+		#expect(noneExporter.convertToOTLP(exemplars: counter.exemplars, metricAttributes: [:]) == nil)
 
 		// Decision keeps only the sampled span.
 		let selectiveExporter = Exporter(timeReference: timeReference, exemplarSamplingDecision: { $0.id == sampledSpan.id })
-		let attached = try #require(selectiveExporter.convertToOTLP(exemplars: counter.exemplars, key: [:]))
+		let attached = try #require(selectiveExporter.convertToOTLP(exemplars: counter.exemplars, metricAttributes: [:]))
 		#expect(attached.map(\.spanId) == [sampledSpan.id])
 
 		// Default decision attaches every exemplar.
 		let defaultExporter = Exporter(timeReference: timeReference)
-		#expect(defaultExporter.convertToOTLP(exemplars: counter.exemplars, key: [:])?.count == 2)
+		#expect(defaultExporter.convertToOTLP(exemplars: counter.exemplars, metricAttributes: [:])?.count == 2)
 	}
 
 	@Test

--- a/Tests/NautilusTelemetryTests/Metrics/MetricExporterTests.swift
+++ b/Tests/NautilusTelemetryTests/Metrics/MetricExporterTests.swift
@@ -67,6 +67,111 @@ struct MetricExporterTests {
 	}
 
 	@Test
+	func counterExemplars() throws {
+		let counter = Counter<Int>(name: "ByteCounter", unit: unit, description: "Counts accumulated bytes")
+
+		let span = InstrumentationSystem.tracer.startSpan(name: "exemplarSpan")
+		span.addAttribute("http.target", "/checkout")
+		span.end()
+
+		let attributes: TelemetryAttributes = ["route": "home"]
+		counter.add(1, attributes: attributes)
+		counter.addExemplar(span: span, value: 1, attributes: attributes)
+
+		let timeReference = TimeReference(serverOffset: 0)
+		let exporter = Exporter(timeReference: timeReference)
+
+		let metric = counter.exportOTLP(exporter)
+		let json = try exporter.encodeJSON(metric)
+
+		// spanId/traceId/filteredAttributes vary per run, so redact them along with the timestamps.
+		let normalizedJsonString = try #require(try TestDataNormalization.normalizedJsonString(
+			data: json,
+			keyValuesToRedact: redaction + ["attributes", "filteredAttributes", "spanId", "traceId"]
+		))
+
+		let expectedOutput =
+			#"{"description":"Counts accumulated bytes","name":"ByteCounter","sum":{"aggregationTemporality":1,"dataPoints":[{"asDouble":1,"asInt":"1","attributes":"***","exemplars":[{"asDouble":1,"asInt":"1","filteredAttributes":"***","spanId":"***","timeUnixNano":"***","traceId":"***"}],"startTimeUnixNano":"***","timeUnixNano":"***"}],"isMonotonic":true},"unit":"bytes"}"#
+
+		#expect(normalizedJsonString == expectedOutput)
+	}
+
+	@Test
+	func exemplarSnapshotAndReset() throws {
+		let counter = Counter<Int>(name: "ByteCounter", unit: unit, description: "Counts accumulated bytes")
+
+		let span = InstrumentationSystem.tracer.startSpan(name: "exemplarSpan")
+		span.end()
+
+		counter.add(1)
+		counter.addExemplar(span: span, value: 1)
+
+		#expect(counter.exemplarSpans.count == 1)
+
+		let snapshot = try #require(counter.snapshotAndReset() as? Counter<Int>)
+
+		// Exemplars move to the snapshot; the live instrument is reset.
+		#expect(snapshot.exemplarSpans.map(\.id) == [span.id])
+		#expect(counter.exemplarSpans.isEmpty)
+	}
+
+	@Test
+	func exemplarsMatchDataPointAttributes() throws {
+		let counter = Counter<Int>(name: "ByteCounter", unit: unit, description: "Counts accumulated bytes")
+
+		let homeSpan = InstrumentationSystem.tracer.startSpan(name: "home")
+		homeSpan.end()
+		let cartSpan = InstrumentationSystem.tracer.startSpan(name: "cart")
+		cartSpan.end()
+
+		let home: TelemetryAttributes = ["route": "home"]
+		let cart: TelemetryAttributes = ["route": "cart"]
+
+		counter.addExemplar(span: homeSpan, value: 1, attributes: home)
+		counter.addExemplar(span: cartSpan, value: 1, attributes: cart)
+
+		let timeReference = TimeReference(serverOffset: 0)
+		let exporter = Exporter(timeReference: timeReference)
+
+		// Exemplars only attach to the data point sharing their aggregation key.
+		let homeExemplars = try #require(exporter.convertToOTLP(exemplars: counter.exemplars, key: home))
+		#expect(homeExemplars.map(\.spanId) == [homeSpan.id])
+
+		let cartExemplars = try #require(exporter.convertToOTLP(exemplars: counter.exemplars, key: cart))
+		#expect(cartExemplars.map(\.spanId) == [cartSpan.id])
+
+		#expect(exporter.convertToOTLP(exemplars: counter.exemplars, key: ["route": "search"]) == nil)
+	}
+
+	@Test
+	func exemplarSamplingDecision() throws {
+		let counter = Counter<Int>(name: "ByteCounter", unit: unit, description: "Counts accumulated bytes")
+
+		let sampledSpan = InstrumentationSystem.tracer.startSpan(name: "sampled")
+		sampledSpan.end()
+		let unsampledSpan = InstrumentationSystem.tracer.startSpan(name: "unsampled")
+		unsampledSpan.end()
+
+		counter.addExemplar(span: sampledSpan, value: 1)
+		counter.addExemplar(span: unsampledSpan, value: 1)
+
+		let timeReference = TimeReference(serverOffset: 0)
+
+		// Decision drops everything: no exemplars are attached.
+		let noneExporter = Exporter(timeReference: timeReference, exemplarSamplingDecision: { _ in false })
+		#expect(noneExporter.convertToOTLP(exemplars: counter.exemplars, key: [:]) == nil)
+
+		// Decision keeps only the sampled span.
+		let selectiveExporter = Exporter(timeReference: timeReference, exemplarSamplingDecision: { $0.id == sampledSpan.id })
+		let attached = try #require(selectiveExporter.convertToOTLP(exemplars: counter.exemplars, key: [:]))
+		#expect(attached.map(\.spanId) == [sampledSpan.id])
+
+		// Default decision attaches every exemplar.
+		let defaultExporter = Exporter(timeReference: timeReference)
+		#expect(defaultExporter.convertToOTLP(exemplars: counter.exemplars, key: [:])?.count == 2)
+	}
+
+	@Test
 	func upDownCounter() throws {
 		let counter = UpDownCounter<Int>(name: "ByteCounter", unit: unit, description: "Counts accumulated bytes")
 

--- a/Tests/NautilusTelemetryTests/Reporters/ExampleReporterTests.swift
+++ b/Tests/NautilusTelemetryTests/Reporters/ExampleReporterTests.swift
@@ -35,4 +35,15 @@ struct ExampleReporterTests {
 		#expect(reporter.sampledSpans([span]).count == 0)
 	}
 
+	@Test("shouldSampleSpan drives exemplar attachment from the per-span decision")
+	func shouldSampleSpan_honorsOverride() {
+		let always = tracer.startSpan(name: "always")
+		always.sampleRate = 100.0
+		#expect(reporter.shouldSampleSpan(always))
+
+		let never = tracer.startSpan(name: "never")
+		never.sampleRate = 0.0
+		#expect(!reporter.shouldSampleSpan(never))
+	}
+
 }

--- a/Tests/NautilusTelemetryTests/Tracing/Tracer+MetricsTests.swift
+++ b/Tests/NautilusTelemetryTests/Tracing/Tracer+MetricsTests.swift
@@ -35,7 +35,7 @@ struct TracerMetricsTests {
 	}
 
 	@Test
-	func reportAsDurationHistogramMetricCopiesSelectedSpanAttributes() {
+	func reportAsDurationHistogramMetricCopiesSelectedSpanAttributes() throws {
 		let span = tracer.startSpan(name: "histogramAttrSpan")
 		span.addAttribute("route", "/users/:id")
 		span.addAttribute("excluded", "nope")
@@ -49,6 +49,7 @@ struct TracerMetricsTests {
 		span.addAttribute("method", "GET")
 		span.adjust(start: .zero, end: .milliseconds(42))
 		span.end()
+		let elapsed = try #require(span.elapsed)
 
 		let expected: TelemetryAttributes = [
 			"route": "/users/:id",
@@ -56,7 +57,44 @@ struct TracerMetricsTests {
 		]
 		let buckets = histogram.values.values[expected]
 		#expect(buckets?.count == 1)
-		#expect(buckets?.sum == 42)
+		#expect(buckets?.sum == Int(elapsed.asMilliseconds))
+	}
+
+	@Test
+	func reportAsDurationHistogramMetricHonorsUnit() throws {
+		// Seconds: inject a ~2s duration so the recorded value distinguishes seconds from finer units, then
+		// assert against the span's own frozen elapsed so the real wall-clock component can't cause flakiness.
+		let secondsSpan = tracer.startSpan(name: "secondsDurationSpan")
+		let secondsHistogram = tracer.reportAsDurationHistogramMetric(span: secondsSpan, unit: .seconds)
+		secondsSpan.adjust(start: .zero, end: .seconds(2))
+		secondsSpan.end()
+		let secondsElapsed = try #require(secondsSpan.elapsed)
+
+		#expect(secondsHistogram.unit?.symbol == "s")
+		#expect(secondsHistogram.values.values[[:]]?.sum == Int(secondsElapsed.asSeconds))
+
+		// Microseconds: the value is recorded from span.elapsed during end(), so assert the histogram
+		// captured the span's actual elapsed converted to microseconds. Reading elapsed after end() yields
+		// the same frozen value the retire callback used, so this is deterministic regardless of wall-clock timing.
+		let microSpan = tracer.startSpan(name: "microDurationSpan")
+		let microHistogram = tracer.reportAsDurationHistogramMetric(span: microSpan, unit: .microseconds)
+		microSpan.end()
+		let microElapsed = try #require(microSpan.elapsed)
+
+		#expect(microHistogram.unit?.symbol == "µs")
+		#expect(microHistogram.values.values[[:]]?.sum == Int(microElapsed.asMicroseconds))
+	}
+
+	@Test
+	func reportAsDurationHistogramMetricDefaultsToMilliseconds() throws {
+		let span = tracer.startSpan(name: "defaultUnitDurationSpan")
+		let histogram = tracer.reportAsDurationHistogramMetric(span: span)
+		span.adjust(start: .zero, end: .milliseconds(42))
+		span.end()
+		let elapsed = try #require(span.elapsed)
+
+		#expect(histogram.unit?.symbol == "ms")
+		#expect(histogram.values.values[[:]]?.sum == Int(elapsed.asMilliseconds))
 	}
 
 	@Test

--- a/Tests/NautilusTelemetryTests/Utilities/FlushTimerTests.swift
+++ b/Tests/NautilusTelemetryTests/Utilities/FlushTimerTests.swift
@@ -123,7 +123,7 @@ final class FlushTimerTests: XCTestCase {
 
 		// Drain any handler invocation already in flight when we suspended, so the
 		// snapshot below reflects a quiesced timer (the queue is serial).
-		NautilusTelemetry.queue.sync {}
+		NautilusTelemetry.queue.sync { }
 		let countAtSuspend = state.withLock { $0.handlerCallCount }
 		Thread.sleep(forTimeInterval: 0.3)
 		XCTAssertEqual(state.withLock { $0.handlerCallCount }, countAtSuspend, "suspended timer must not fire")

--- a/Tests/NautilusTelemetryTests/Utilities/TimeReferenceTests.swift
+++ b/Tests/NautilusTelemetryTests/Utilities/TimeReferenceTests.swift
@@ -75,6 +75,36 @@ struct TimeReferenceTests {
 		#expect(Duration(secondsComponent: -1, attosecondsComponent: -500_000_000_000_000).asMilliseconds == -1001)
 	}
 
+	@Test("Microsecond rounding")
+	func microsecondsRounding() {
+		#expect(Duration.microseconds(0).asMicroseconds == 0)
+		#expect(Duration.microseconds(5).asMicroseconds == 5)
+		#expect(Duration.microseconds(-5).asMicroseconds == -5)
+
+		// Just below the half-us threshold (499_999_999_999 as) — truncates.
+		#expect(Duration(secondsComponent: 1, attosecondsComponent: 499_999_999_999).asMicroseconds == 1_000_000)
+		#expect(Duration(secondsComponent: -1, attosecondsComponent: -499_999_999_999).asMicroseconds == -1_000_000)
+
+		// Exactly at the half-us threshold (500_000_000_000 as) — rounds away from zero.
+		#expect(Duration(secondsComponent: 1, attosecondsComponent: 500_000_000_000).asMicroseconds == 1_000_001)
+		#expect(Duration(secondsComponent: -1, attosecondsComponent: -500_000_000_000).asMicroseconds == -1_000_001)
+	}
+
+	@Test("Second rounding")
+	func secondsRounding() {
+		#expect(Duration.seconds(0).asSeconds == 0)
+		#expect(Duration.seconds(5).asSeconds == 5)
+		#expect(Duration.seconds(-5).asSeconds == -5)
+
+		// Just below the half-second threshold — truncates toward zero.
+		#expect(Duration(secondsComponent: 1, attosecondsComponent: 499_999_999_999_999_999).asSeconds == 1)
+		#expect(Duration(secondsComponent: -1, attosecondsComponent: -499_999_999_999_999_999).asSeconds == -1)
+
+		// Exactly at the half-second threshold — rounds away from zero.
+		#expect(Duration(secondsComponent: 1, attosecondsComponent: 500_000_000_000_000_000).asSeconds == 2)
+		#expect(Duration(secondsComponent: -1, attosecondsComponent: -500_000_000_000_000_000).asSeconds == -2)
+	}
+
 	#if os(macOS)
 	@Test("Infinite and NaN")
 	func infiniteAndNan() async {


### PR DESCRIPTION
## Summary

Adds OpenTelemetry metric **exemplar** support — a sampled measurement plus a link back to the trace that produced it.

- Instruments record exemplars via `addExemplar(span:value:attributes:)`, stored thread-safely (`Mutex<[Exemplar<T>]>`) alongside their values and drained on `snapshotAndReset()`.
- `Tracer+Metrics` records the exemplar inside the span retire callback, where the real measurement value (and collected attributes) is known.
- The exporter attaches exemplars to the matching data point by aggregation key, emitting `asDouble`/`asInt`, span/trace IDs, and `filteredAttributes`.
- `Exporter.exemplarSamplingDecision` lets a reporter gate exemplar attachment on the trace sampling decision. `ExampleReporter` demonstrates reusing its per-span decision.
- Made `parentId` public for ease of integration testing. 

`addExemplar` stays on the concrete generic instruments (like `add`/`record`/`observe`); `exemplarSpans` remains on the `Instrument` protocol for type-erased read access.

## Testing

`swift test` — all suites pass, including new coverage for exemplar wiring, attribute matching, snapshot/reset, and the sampling decision.

@jparise 
@bachand
